### PR TITLE
feat: early redirect for image

### DIFF
--- a/image/src/index.ts
+++ b/image/src/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 
-import { Env, CACHE_MONTH } from './utils/constants';
+import { Env, CACHE_MONTH, CACHE_TTL_BY_STATUS } from './utils/constants';
 import { uploadToCloudflareImages } from './utils/cloudflare-images';
 
 const app = new Hono<{ Bindings: Env }>();
@@ -76,13 +76,7 @@ app.all('/ipfs/:cid', async (c) => {
       const cfImage = `https://imagedelivery.net/${c.env.CF_IMAGE_ID}/${cid}/public`;
       const currentImage = await fetch(cfImage, {
         method: 'HEAD',
-        cf: {
-          cacheTtlByStatus: {
-            '200-299': CACHE_MONTH,
-            '404': 1,
-            '500-599': 0,
-          },
-        },
+        cf: CACHE_TTL_BY_STATUS,
       });
 
       // return early to cf-images

--- a/image/src/index.ts
+++ b/image/src/index.ts
@@ -1,19 +1,8 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 
+import { Env, CACHE_MONTH } from './utils/constants';
 import { uploadToCloudflareImages } from './utils/cloudflare-images';
-
-interface Env {
-  MY_BUCKET: R2Bucket;
-  DEDICATED_GATEWAY: string;
-  DEDICATED_BACKUP_GATEWAY: string;
-  CLOUDFLARE_GATEWAY: string;
-  CF_IMAGE_ACCOUNT: string;
-  CF_IMAGE_ID: string;
-
-  // wrangler secret
-  IMAGE_API_TOKEN: string;
-}
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -84,7 +73,24 @@ app.all('/ipfs/:cid', async (c) => {
     }
 
     if (!response) {
-      // else, redirect to cf-images or render existing r2 object
+      const cfImage = `https://imagedelivery.net/${c.env.CF_IMAGE_ID}/${cid}/public`;
+      const currentImage = await fetch(cfImage, {
+        method: 'HEAD',
+        cf: {
+          cacheTtlByStatus: {
+            '200-299': CACHE_MONTH,
+            '404': 1,
+            '500-599': 0,
+          },
+        },
+      });
+
+      // return early to cf-images
+      if (currentImage.ok) {
+        return Response.redirect(cfImage, 302);
+      }
+
+      // else, upload to cf-images
       const imageUrl = await uploadToCloudflareImages({
         cid,
         token: c.env.IMAGE_API_TOKEN,
@@ -109,7 +115,7 @@ app.all('/ipfs/:cid', async (c) => {
         headers,
       });
 
-      response.headers.append('Cache-Control', 's-maxage=86400');
+      response.headers.append('Cache-Control', `s-maxage=${CACHE_MONTH}`);
       c.executionCtx.waitUntil(cache.put(cacheKey, response.clone()));
     }
 

--- a/image/src/utils/constants.ts
+++ b/image/src/utils/constants.ts
@@ -1,7 +1,3 @@
-export const CACHE_DAY = 86400;
-export const CACHE_WEEK = CACHE_DAY * 7;
-export const CACHE_MONTH = CACHE_DAY * 30;
-
 export interface Env {
   MY_BUCKET: R2Bucket;
   DEDICATED_GATEWAY: string;
@@ -13,3 +9,16 @@ export interface Env {
   // wrangler secret
   IMAGE_API_TOKEN: string;
 }
+
+export const CACHE_SECOND = 1;
+export const CACHE_DAY = 86400;
+export const CACHE_WEEK = CACHE_DAY * 7;
+export const CACHE_MONTH = CACHE_DAY * 30;
+
+export const CACHE_TTL_BY_STATUS = {
+  cacheTtlByStatus: {
+    '200-299': CACHE_MONTH,
+    '404': CACHE_SECOND,
+    '500-599': 0,
+  },
+};

--- a/image/src/utils/constants.ts
+++ b/image/src/utils/constants.ts
@@ -1,0 +1,15 @@
+export const CACHE_DAY = 86400;
+export const CACHE_WEEK = CACHE_DAY * 7;
+export const CACHE_MONTH = CACHE_DAY * 30;
+
+export interface Env {
+  MY_BUCKET: R2Bucket;
+  DEDICATED_GATEWAY: string;
+  DEDICATED_BACKUP_GATEWAY: string;
+  CLOUDFLARE_GATEWAY: string;
+  CF_IMAGE_ACCOUNT: string;
+  CF_IMAGE_ID: string;
+
+  // wrangler secret
+  IMAGE_API_TOKEN: string;
+}


### PR DESCRIPTION
- [x] closes https://github.com/kodadot/nft-gallery/issues/4595

| before | after |
| --- | --- |
| <img width="1624" alt="Screenshot 2023-01-07 at 20 13 25" src="https://user-images.githubusercontent.com/734428/211153231-e310f7b2-ed01-4e9a-bfe4-47a211677f20.png"> | <img width="1624" alt="Screenshot 2023-01-07 at 20 12 23" src="https://user-images.githubusercontent.com/734428/211153252-f54a7767-6a0c-4e84-b511-e8f90980eebc.png"> |

on already uploaded images to cf-images and hit the fetch cache will be faster (<1s). on a new image still takes > 1s