### PR TITLE
:construction_worker: Manual deploy to cf workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy to Cloudflare workers
+on:
+  workflow_dispatch:
+    inputs:
+      worker:
+        description: 'Name of the worker'     
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - uses: actions/checkout@v3
+      - name: Publish
+        uses: cloudflare/wrangler-action@2.0.0
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          workingDirectory: ${{ github.event.inputs.worker }}


### PR DESCRIPTION
I am trying to learn github actions 🥺 

Ref: 
- https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

- https://github.com/marketplace/actions/deploy-to-cloudflare-workers-with-wrangler