### PR TITLE
feat: init ssr-opengraph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules

--- a/prerender-opengraph/wrangler.toml
+++ b/prerender-opengraph/wrangler.toml
@@ -4,13 +4,10 @@ main = "src/index.ts"
 compatibility_date = "2022-06-24"
 routes = [
   "kodadot.xyz/rmrk/collection/*",
-  "kodadot.xyz/rmrk/gallery/*",
   "kodadot.xyz/rmrk/detail/*",
   "kodadot.xyz/bsx/collection/*",
-  "kodadot.xyz/bsx/gallery/*",
   "kodadot.xyz/bsx/detail/*",
   "kodadot.xyz/snek/collection/*",
-  "kodadot.xyz/snek/gallery/*",
   "kodadot.xyz/snek/detail/*",
   "kodadot.xyz/glmr/collection/*",
   "kodadot.xyz/glmr/gallery/*",

--- a/ssr-opengraph/README.md
+++ b/ssr-opengraph/README.md
@@ -1,0 +1,8 @@
+```
+npm install
+npm run dev
+```
+
+```
+npm run deploy
+```

--- a/ssr-opengraph/package-lock.json
+++ b/ssr-opengraph/package-lock.json
@@ -5,6 +5,10 @@
   "packages": {
     "": {
       "dependencies": {
+        "@kodadot1/minipfs": "0.2.0-rc.0",
+        "@kodadot1/static": "0.0.1-rc.0",
+        "@kodadot1/uniquery": "0.2.2-rc.0",
+        "@polkadot/util": "^11.1.1",
         "hono": "^3.1.2",
         "isbot": "^3.6.7"
       },
@@ -408,6 +412,31 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "dev": true
     },
+    "node_modules/@kodadot1/minipfs": {
+      "version": "0.2.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@kodadot1/minipfs/-/minipfs-0.2.0-rc.0.tgz",
+      "integrity": "sha512-xnH8mFje1x8y5QYzKbpxg2rlHVCI1fGy+YnUGI+WUkuEPTVPwgTlapzDyO8AztGucbqbuk4ELghHcyyZwde2iA==",
+      "dependencies": {
+        "ohmyfetch": "^0.4.20"
+      }
+    },
+    "node_modules/@kodadot1/static": {
+      "version": "0.0.1-rc.0",
+      "resolved": "https://registry.npmjs.org/@kodadot1/static/-/static-0.0.1-rc.0.tgz",
+      "integrity": "sha512-0c91/nU4kyVSA218+vDJHnbGbBxFauuv7LpTXdQHo2vXvxbDou46tvSqN7Ac91SG1blTKhgMe2xWBEBsA4n7Nw=="
+    },
+    "node_modules/@kodadot1/uniquery": {
+      "version": "0.2.2-rc.0",
+      "resolved": "https://registry.npmjs.org/@kodadot1/uniquery/-/uniquery-0.2.2-rc.0.tgz",
+      "integrity": "sha512-QSPT9F4xQymhjs+wxE4UCdr3qmex9xWcaKhf8UUDuxGOeOSiTfpxvmY7Jr1rZ90UJcPbhK0GqTDChesjxnltzg==",
+      "dependencies": {
+        "@kodadot1/static": "0.0.1-rc.0",
+        "gql-query-builder": "^3.8.0",
+        "ofetch": "^1.0.1",
+        "scule": "^1.0.0",
+        "ufo": "^1.1.1"
+      }
+    },
     "node_modules/@miniflare/cache": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.12.1.tgz",
@@ -421,6 +450,18 @@
       },
       "engines": {
         "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/cache/node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "node_modules/@miniflare/cli-parser": {
@@ -457,6 +498,18 @@
         "node": ">=16.13"
       }
     },
+    "node_modules/@miniflare/core/node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
     "node_modules/@miniflare/d1": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.12.1.tgz",
@@ -485,6 +538,18 @@
         "node": ">=16.13"
       }
     },
+    "node_modules/@miniflare/durable-objects/node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
     "node_modules/@miniflare/html-rewriter": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.12.1.tgz",
@@ -498,6 +563,18 @@
       },
       "engines": {
         "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/html-rewriter/node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "node_modules/@miniflare/http-server": {
@@ -517,6 +594,18 @@
       },
       "engines": {
         "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/http-server/node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "node_modules/@miniflare/kv": {
@@ -554,6 +643,18 @@
       },
       "engines": {
         "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/r2/node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "node_modules/@miniflare/runner-vm": {
@@ -663,6 +764,82 @@
         "node": ">=16.13"
       }
     },
+    "node_modules/@miniflare/web-sockets/node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
+    "node_modules/@polkadot/util": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.1.tgz",
+      "integrity": "sha512-8vlSfJhMAck2OVdk8aep3sZP17txR+p8X3bFNP0qNJ7frfF741v/eViEC7bbVIgdT0/vYNmgS6+0Dwe06dnKuA==",
+      "dependencies": {
+        "@polkadot/x-bigint": "11.1.1",
+        "@polkadot/x-global": "11.1.1",
+        "@polkadot/x-textdecoder": "11.1.1",
+        "@polkadot/x-textencoder": "11.1.1",
+        "@types/bn.js": "^5.1.1",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@polkadot/x-bigint": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.1.tgz",
+      "integrity": "sha512-iLaaPSCnVuZ7LoOWZTHgs+Ebws0MdoNHmXoTriU60YLoojDJbcOInlO+1h3fNy6oPnYN3qA3Ml1mKDnP837nxg==",
+      "dependencies": {
+        "@polkadot/x-global": "11.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@polkadot/x-global": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.1.tgz",
+      "integrity": "sha512-++LFUT98bi2m15w8LrgOcpE5mi9bmH65YB02xbKzU0ZHe1g5l0LwFt+QFB9tZlNqfWTgwpsFshGtvdPQqrFnKw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.1.tgz",
+      "integrity": "sha512-YoB82pr6kYkK5yg2BQgm5wVTf6Hq+01i+A6PgV1uXr7Rm3bxmQpGR2DKZq0QNjwWP0s6e91BxXvGoPjf7S9tBA==",
+      "dependencies": {
+        "@polkadot/x-global": "11.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@polkadot/x-textencoder": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.1.tgz",
+      "integrity": "sha512-I4IygnZeSyGUPyTmu7W2IsCHakax7QTVR9kMkCywaKEjiLzZU5B/LuDB0Gxn/3Jw2X2YfoB1TQ4mZ1bte4LX0g==",
+      "dependencies": {
+        "@polkadot/x-global": "11.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.3.tgz",
@@ -672,11 +849,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "18.15.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.5.tgz",
-      "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==",
-      "dev": true
+      "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew=="
     },
     "node_modules/@types/stack-trace": {
       "version": "0.0.29",
@@ -712,6 +896,11 @@
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true
     },
+    "node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
     "node_modules/braces": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -743,7 +932,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
       "dependencies": {
         "streamsearch": "^1.1.0"
       },
@@ -806,6 +994,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/destr": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-1.2.2.tgz",
+      "integrity": "sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA=="
     },
     "node_modules/dotenv": {
       "version": "10.0.0",
@@ -943,6 +1136,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/gql-query-builder": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/gql-query-builder/-/gql-query-builder-3.8.0.tgz",
+      "integrity": "sha512-q0PncZTrLDeyiH4R7YH1ISM+XGB4NvQ8eTm/Wr/sHSuquFZvqvDpGyMhbgoCZDc8kNAK8GOdfh3nI2GCLREFvw=="
     },
     "node_modules/hono": {
       "version": "3.1.2",
@@ -1152,6 +1350,18 @@
         }
       }
     },
+    "node_modules/miniflare/node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
     "node_modules/mustache": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
@@ -1172,6 +1382,11 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.2.tgz",
+      "integrity": "sha512-KIkvH1jl6b3O7es/0ShyCgWLcfXxlBrLBbP3rOr23WArC66IMcU4DeZEeYEOwnopYhawLTn7/y+YtmASe8DFVQ=="
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -1229,6 +1444,37 @@
         "semver": "^7.3.7",
         "validate-npm-package-name": "^4.0.0"
       }
+    },
+    "node_modules/ofetch": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.0.1.tgz",
+      "integrity": "sha512-icBz2JYfEpt+wZz1FRoGcrMigjNKjzvufE26m9+yUiacRQRHwnNlGRPiDnW4op7WX/MR6aniwS8xw8jyVelF2g==",
+      "dependencies": {
+        "destr": "^1.2.2",
+        "node-fetch-native": "^1.0.2",
+        "ufo": "^1.1.0"
+      }
+    },
+    "node_modules/ohmyfetch": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/ohmyfetch/-/ohmyfetch-0.4.21.tgz",
+      "integrity": "sha512-VG7f/JRvqvBOYvL0tHyEIEG7XHWm7OqIfAs6/HqwWwDfjiJ1g0huIpe5sFEmyb+7hpFa1EGNH2aERWR72tlClw==",
+      "dependencies": {
+        "destr": "^1.2.0",
+        "node-fetch-native": "^0.1.8",
+        "ufo": "^0.8.6",
+        "undici": "^5.12.0"
+      }
+    },
+    "node_modules/ohmyfetch/node_modules/node-fetch-native": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-0.1.8.tgz",
+      "integrity": "sha512-ZNaury9r0NxaT2oL65GvdGDy+5PlSaHTovT6JV5tOW07k1TQmgC0olZETa4C9KZg0+6zBr99ctTYa3Utqj9P/Q=="
+    },
+    "node_modules/ohmyfetch/node_modules/ufo": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.6.tgz",
+      "integrity": "sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw=="
     },
     "node_modules/onetime": {
       "version": "6.0.0",
@@ -1319,6 +1565,11 @@
       "dependencies": {
         "estree-walker": "^0.6.1"
       }
+    },
+    "node_modules/scule": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
+      "integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ=="
     },
     "node_modules/selfsigned": {
       "version": "2.1.1",
@@ -1437,7 +1688,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -1466,11 +1716,20 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/ufo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg=="
+    },
     "node_modules/undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-      "dev": true,
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -1783,6 +2042,31 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "dev": true
     },
+    "@kodadot1/minipfs": {
+      "version": "0.2.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@kodadot1/minipfs/-/minipfs-0.2.0-rc.0.tgz",
+      "integrity": "sha512-xnH8mFje1x8y5QYzKbpxg2rlHVCI1fGy+YnUGI+WUkuEPTVPwgTlapzDyO8AztGucbqbuk4ELghHcyyZwde2iA==",
+      "requires": {
+        "ohmyfetch": "^0.4.20"
+      }
+    },
+    "@kodadot1/static": {
+      "version": "0.0.1-rc.0",
+      "resolved": "https://registry.npmjs.org/@kodadot1/static/-/static-0.0.1-rc.0.tgz",
+      "integrity": "sha512-0c91/nU4kyVSA218+vDJHnbGbBxFauuv7LpTXdQHo2vXvxbDou46tvSqN7Ac91SG1blTKhgMe2xWBEBsA4n7Nw=="
+    },
+    "@kodadot1/uniquery": {
+      "version": "0.2.2-rc.0",
+      "resolved": "https://registry.npmjs.org/@kodadot1/uniquery/-/uniquery-0.2.2-rc.0.tgz",
+      "integrity": "sha512-QSPT9F4xQymhjs+wxE4UCdr3qmex9xWcaKhf8UUDuxGOeOSiTfpxvmY7Jr1rZ90UJcPbhK0GqTDChesjxnltzg==",
+      "requires": {
+        "@kodadot1/static": "0.0.1-rc.0",
+        "gql-query-builder": "^3.8.0",
+        "ofetch": "^1.0.1",
+        "scule": "^1.0.0",
+        "ufo": "^1.1.1"
+      }
+    },
     "@miniflare/cache": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.12.1.tgz",
@@ -1793,6 +2077,17 @@
         "@miniflare/shared": "2.12.1",
         "http-cache-semantics": "^4.1.0",
         "undici": "5.20.0"
+      },
+      "dependencies": {
+        "undici": {
+          "version": "5.20.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+          "dev": true,
+          "requires": {
+            "busboy": "^1.6.0"
+          }
+        }
       }
     },
     "@miniflare/cli-parser": {
@@ -1821,6 +2116,17 @@
         "set-cookie-parser": "^2.4.8",
         "undici": "5.20.0",
         "urlpattern-polyfill": "^4.0.3"
+      },
+      "dependencies": {
+        "undici": {
+          "version": "5.20.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+          "dev": true,
+          "requires": {
+            "busboy": "^1.6.0"
+          }
+        }
       }
     },
     "@miniflare/d1": {
@@ -1843,6 +2149,17 @@
         "@miniflare/shared": "2.12.1",
         "@miniflare/storage-memory": "2.12.1",
         "undici": "5.20.0"
+      },
+      "dependencies": {
+        "undici": {
+          "version": "5.20.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+          "dev": true,
+          "requires": {
+            "busboy": "^1.6.0"
+          }
+        }
       }
     },
     "@miniflare/html-rewriter": {
@@ -1855,6 +2172,17 @@
         "@miniflare/shared": "2.12.1",
         "html-rewriter-wasm": "^0.4.1",
         "undici": "5.20.0"
+      },
+      "dependencies": {
+        "undici": {
+          "version": "5.20.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+          "dev": true,
+          "requires": {
+            "busboy": "^1.6.0"
+          }
+        }
       }
     },
     "@miniflare/http-server": {
@@ -1871,6 +2199,17 @@
         "undici": "5.20.0",
         "ws": "^8.2.2",
         "youch": "^2.2.2"
+      },
+      "dependencies": {
+        "undici": {
+          "version": "5.20.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+          "dev": true,
+          "requires": {
+            "busboy": "^1.6.0"
+          }
+        }
       }
     },
     "@miniflare/kv": {
@@ -1899,6 +2238,17 @@
       "requires": {
         "@miniflare/shared": "2.12.1",
         "undici": "5.20.0"
+      },
+      "dependencies": {
+        "undici": {
+          "version": "5.20.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+          "dev": true,
+          "requires": {
+            "busboy": "^1.6.0"
+          }
+        }
       }
     },
     "@miniflare/runner-vm": {
@@ -1982,6 +2332,66 @@
         "@miniflare/shared": "2.12.1",
         "undici": "5.20.0",
         "ws": "^8.2.2"
+      },
+      "dependencies": {
+        "undici": {
+          "version": "5.20.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+          "dev": true,
+          "requires": {
+            "busboy": "^1.6.0"
+          }
+        }
+      }
+    },
+    "@polkadot/util": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-11.1.1.tgz",
+      "integrity": "sha512-8vlSfJhMAck2OVdk8aep3sZP17txR+p8X3bFNP0qNJ7frfF741v/eViEC7bbVIgdT0/vYNmgS6+0Dwe06dnKuA==",
+      "requires": {
+        "@polkadot/x-bigint": "11.1.1",
+        "@polkadot/x-global": "11.1.1",
+        "@polkadot/x-textdecoder": "11.1.1",
+        "@polkadot/x-textencoder": "11.1.1",
+        "@types/bn.js": "^5.1.1",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@polkadot/x-bigint": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-11.1.1.tgz",
+      "integrity": "sha512-iLaaPSCnVuZ7LoOWZTHgs+Ebws0MdoNHmXoTriU60YLoojDJbcOInlO+1h3fNy6oPnYN3qA3Ml1mKDnP837nxg==",
+      "requires": {
+        "@polkadot/x-global": "11.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@polkadot/x-global": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-11.1.1.tgz",
+      "integrity": "sha512-++LFUT98bi2m15w8LrgOcpE5mi9bmH65YB02xbKzU0ZHe1g5l0LwFt+QFB9tZlNqfWTgwpsFshGtvdPQqrFnKw==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@polkadot/x-textdecoder": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-11.1.1.tgz",
+      "integrity": "sha512-YoB82pr6kYkK5yg2BQgm5wVTf6Hq+01i+A6PgV1uXr7Rm3bxmQpGR2DKZq0QNjwWP0s6e91BxXvGoPjf7S9tBA==",
+      "requires": {
+        "@polkadot/x-global": "11.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@polkadot/x-textencoder": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-11.1.1.tgz",
+      "integrity": "sha512-I4IygnZeSyGUPyTmu7W2IsCHakax7QTVR9kMkCywaKEjiLzZU5B/LuDB0Gxn/3Jw2X2YfoB1TQ4mZ1bte4LX0g==",
+      "requires": {
+        "@polkadot/x-global": "11.1.1",
+        "tslib": "^2.5.0"
       }
     },
     "@types/better-sqlite3": {
@@ -1993,11 +2403,18 @@
         "@types/node": "*"
       }
     },
+    "@types/bn.js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "18.15.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.5.tgz",
-      "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==",
-      "dev": true
+      "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew=="
     },
     "@types/stack-trace": {
       "version": "0.0.29",
@@ -2027,6 +2444,11 @@
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true
     },
+    "bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
     "braces": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -2055,7 +2477,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
       "requires": {
         "streamsearch": "^1.1.0"
       }
@@ -2098,6 +2519,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "destr": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-1.2.2.tgz",
+      "integrity": "sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA=="
     },
     "dotenv": {
       "version": "10.0.0",
@@ -2194,6 +2620,11 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
+    },
+    "gql-query-builder": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/gql-query-builder/-/gql-query-builder-3.8.0.tgz",
+      "integrity": "sha512-q0PncZTrLDeyiH4R7YH1ISM+XGB4NvQ8eTm/Wr/sHSuquFZvqvDpGyMhbgoCZDc8kNAK8GOdfh3nI2GCLREFvw=="
     },
     "hono": {
       "version": "3.1.2",
@@ -2334,6 +2765,17 @@
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
         "undici": "5.20.0"
+      },
+      "dependencies": {
+        "undici": {
+          "version": "5.20.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+          "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+          "dev": true,
+          "requires": {
+            "busboy": "^1.6.0"
+          }
+        }
       }
     },
     "mustache": {
@@ -2347,6 +2789,11 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "dev": true
+    },
+    "node-fetch-native": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.2.tgz",
+      "integrity": "sha512-KIkvH1jl6b3O7es/0ShyCgWLcfXxlBrLBbP3rOr23WArC66IMcU4DeZEeYEOwnopYhawLTn7/y+YtmASe8DFVQ=="
     },
     "node-forge": {
       "version": "1.3.1",
@@ -2387,6 +2834,39 @@
         "parse-package-name": "^1.0.0",
         "semver": "^7.3.7",
         "validate-npm-package-name": "^4.0.0"
+      }
+    },
+    "ofetch": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.0.1.tgz",
+      "integrity": "sha512-icBz2JYfEpt+wZz1FRoGcrMigjNKjzvufE26m9+yUiacRQRHwnNlGRPiDnW4op7WX/MR6aniwS8xw8jyVelF2g==",
+      "requires": {
+        "destr": "^1.2.2",
+        "node-fetch-native": "^1.0.2",
+        "ufo": "^1.1.0"
+      }
+    },
+    "ohmyfetch": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/ohmyfetch/-/ohmyfetch-0.4.21.tgz",
+      "integrity": "sha512-VG7f/JRvqvBOYvL0tHyEIEG7XHWm7OqIfAs6/HqwWwDfjiJ1g0huIpe5sFEmyb+7hpFa1EGNH2aERWR72tlClw==",
+      "requires": {
+        "destr": "^1.2.0",
+        "node-fetch-native": "^0.1.8",
+        "ufo": "^0.8.6",
+        "undici": "^5.12.0"
+      },
+      "dependencies": {
+        "node-fetch-native": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-0.1.8.tgz",
+          "integrity": "sha512-ZNaury9r0NxaT2oL65GvdGDy+5PlSaHTovT6JV5tOW07k1TQmgC0olZETa4C9KZg0+6zBr99ctTYa3Utqj9P/Q=="
+        },
+        "ufo": {
+          "version": "0.8.6",
+          "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.6.tgz",
+          "integrity": "sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw=="
+        }
       }
     },
     "onetime": {
@@ -2459,6 +2939,11 @@
       "requires": {
         "estree-walker": "^0.6.1"
       }
+    },
+    "scule": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
+      "integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ=="
     },
     "selfsigned": {
       "version": "2.1.1",
@@ -2550,8 +3035,7 @@
     "streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "strip-final-newline": {
       "version": "3.0.0",
@@ -2568,11 +3052,20 @@
         "is-number": "^7.0.0"
       }
     },
+    "tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "ufo": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
+      "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg=="
+    },
     "undici": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
-      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-      "dev": true,
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "requires": {
         "busboy": "^1.6.0"
       }

--- a/ssr-opengraph/package-lock.json
+++ b/ssr-opengraph/package-lock.json
@@ -1,0 +1,2660 @@
+{
+  "name": "ssr-opengraph",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "hono": "^3.1.2",
+        "isbot": "^3.6.7"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20230307.0",
+        "wrangler": "^2.13.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.2.0.tgz",
+      "integrity": "sha512-MVbXLbTcAotOPUj0pAMhVtJ+3/kFkwJqc5qNOleOZTv6QkZZABDMS21dSrSlVswEHwrpWC03e4fWytjqKvuE2A==",
+      "dev": true,
+      "dependencies": {
+        "mime": "^3.0.0"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20230321.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20230321.0.tgz",
+      "integrity": "sha512-zyRFz9AUS0tbg3/kJ+3zxvp9fl/O9yOJlChih/o86hhOqRMcZVbWefYAvFPidRvYUHM5YTG1wjU1bF9FFckRVg==",
+      "dev": true
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.1.1.tgz",
+      "integrity": "sha512-MR0oAA+mlnJWrt1RQVQ+4VYuRJW/P2YmRTv1AsplObyvuBMnPHiizUF95HHYiSsMGLhyGtWufaq2XQg6+iurBg==",
+      "dev": true,
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.1.4.tgz",
+      "integrity": "sha512-uZbcXi0zbmKC/050p3gJnne5Qdzw8vkXIv+c2BW0Lsc1ji1SkrxbKPUy5Efr0blbTu1SL8w4eyfpnSdPg3G0Qg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.3.tgz",
+      "integrity": "sha512-mueuEoh+s1eRbSJqq9KNBQwI4QhQV6sRXIfTyLXSHGMpyew61rOK4qY21uKbXl1iBoMb0AdL1deWFCQVlN2qHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.3.tgz",
+      "integrity": "sha512-RolFVeinkeraDvN/OoRf1F/lP0KUfGNb5jxy/vkIMeRRChkrX/HTYN6TYZosRJs3a1+8wqpxAo5PI5hFmxyPRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.3.tgz",
+      "integrity": "sha512-SFpTUcIT1bIJuCCBMCQWq1bL2gPTjWoLZdjmIhjdcQHaUfV41OQfho6Ici5uvvkMmZRXIUGpM3GxysP/EU7ifQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.3.tgz",
+      "integrity": "sha512-DO8WykMyB+N9mIDfI/Hug70Dk1KipavlGAecxS3jDUwAbTpDXj0Lcwzw9svkhxfpCagDmpaTMgxWK8/C/XcXvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.3.tgz",
+      "integrity": "sha512-uEqZQ2omc6BvWqdCiyZ5+XmxuHEi1SPzpVxXCSSV2+Sh7sbXbpeNhHIeFrIpRjAs0lI1FmA1iIOxFozKBhKgRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.3.tgz",
+      "integrity": "sha512-nJansp3sSXakNkOD5i5mIz2Is/HjzIhFs49b1tjrPrpCmwgBmH9SSzhC/Z1UqlkivqMYkhfPwMw1dGFUuwmXhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.3.tgz",
+      "integrity": "sha512-TfoDzLw+QHfc4a8aKtGSQ96Wa+6eimljjkq9HKR0rHlU83vw8aldMOUSJTUDxbcUdcgnJzPaX8/vGWm7vyV7ug==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.3.tgz",
+      "integrity": "sha512-VwswmSYwVAAq6LysV59Fyqk3UIjbhuc6wb3vEcJ7HEJUtFuLK9uXWuFoH1lulEbE4+5GjtHi3MHX+w1gNHdOWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.3.tgz",
+      "integrity": "sha512-7I3RlsnxEFCHVZNBLb2w7unamgZ5sVwO0/ikE2GaYvYuUQs9Qte/w7TqWcXHtCwxvZx/2+F97ndiUQAWs47ZfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.3.tgz",
+      "integrity": "sha512-X8FDDxM9cqda2rJE+iblQhIMYY49LfvW4kaEjoFbTTQ4Go8G96Smj2w3BRTwA8IHGoi9dPOPGAX63dhuv19UqA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.3.tgz",
+      "integrity": "sha512-hIbeejCOyO0X9ujfIIOKjBjNAs9XD/YdJ9JXAy1lHA+8UXuOqbFe4ErMCqMr8dhlMGBuvcQYGF7+kO7waj2KHw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.3.tgz",
+      "integrity": "sha512-znFRzICT/V8VZQMt6rjb21MtAVJv/3dmKRMlohlShrbVXdBuOdDrGb+C2cZGQAR8RFyRe7HS6klmHq103WpmVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.3.tgz",
+      "integrity": "sha512-EV7LuEybxhXrVTDpbqWF2yehYRNz5e5p+u3oQUS2+ZFpknyi1NXxr8URk4ykR8Efm7iu04//4sBg249yNOwy5Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.3.tgz",
+      "integrity": "sha512-uDxqFOcLzFIJ+r/pkTTSE9lsCEaV/Y6rMlQjUI9BkzASEChYL/aSQjZjchtEmdnVxDKETnUAmsaZ4pqK1eE5BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.3.tgz",
+      "integrity": "sha512-NbeREhzSxYwFhnCAQOQZmajsPYtX71Ufej3IQ8W2Gxskfz9DK58ENEju4SbpIj48VenktRASC52N5Fhyf/aliQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.3.tgz",
+      "integrity": "sha512-SDiG0nCixYO9JgpehoKgScwic7vXXndfasjnD5DLbp1xltANzqZ425l7LSdHynt19UWOcDjG9wJJzSElsPvk0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.3.tgz",
+      "integrity": "sha512-AzbsJqiHEq1I/tUvOfAzCY15h4/7Ivp3ff/o1GpP16n48JMNAtbW0qui2WCgoIZArEHD0SUQ95gvR0oSO7ZbdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.3.tgz",
+      "integrity": "sha512-gSABi8qHl8k3Cbi/4toAzHiykuBuWLZs43JomTcXkjMZVkp0gj3gg9mO+9HJW/8GB5H89RX/V0QP4JGL7YEEVg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.3.tgz",
+      "integrity": "sha512-SF9Kch5Ete4reovvRO6yNjMxrvlfT0F0Flm+NPoUw5Z4Q3r1d23LFTgaLwm3Cp0iGbrU/MoUI+ZqwCv5XJijCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.3.tgz",
+      "integrity": "sha512-u5aBonZIyGopAZyOnoPAA6fGsDeHByZ9CnEzyML9NqntK6D/xl5jteZUKm/p6nD09+v3pTM6TuUIqSPcChk5gg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.3.tgz",
+      "integrity": "sha512-GlgVq1WpvOEhNioh74TKelwla9KDuAaLZrdxuuUgsP2vayxeLgVc+rbpIv0IYF4+tlIzq2vRhofV+KGLD+37EQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.3.tgz",
+      "integrity": "sha512-5/JuTd8OWW8UzEtyf19fbrtMJENza+C9JoPIkvItgTBQ1FO2ZLvjbPO6Xs54vk0s5JB5QsfieUEshRQfu7ZHow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "dev": true
+    },
+    "node_modules/@miniflare/cache": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.12.1.tgz",
+      "integrity": "sha512-6Pj5avy53qULTa13gWxGTDBuwX0yAzr4Zkzb0ZBh40bcbHp4vRkOk7PvHBoxV0M76JxQDHotGaW+ik510z5Xrg==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "http-cache-semantics": "^4.1.0",
+        "undici": "5.20.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/cli-parser": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.12.1.tgz",
+      "integrity": "sha512-iCh4wEyQow8Dha+zpKhjCCXEp6QWbsvE18H5CgeUFT1pX4B+akYIHzdn47Cr5zpuYyjenoL78bAz0IIHIeyeWw==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/shared": "2.12.1",
+        "kleur": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/core": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.12.1.tgz",
+      "integrity": "sha512-729xXL6uoMgtja5J7B2WdWAjFfxb74Pk2QqM3VqkWqY3XNlKWI7+ofvb8S6kI6uFEPGj4ma263uYkEAgsvzBWg==",
+      "dev": true,
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "@miniflare/queues": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/watcher": "2.12.1",
+        "busboy": "^1.6.0",
+        "dotenv": "^10.0.0",
+        "kleur": "^4.1.4",
+        "set-cookie-parser": "^2.4.8",
+        "undici": "5.20.0",
+        "urlpattern-polyfill": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/d1": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.12.1.tgz",
+      "integrity": "sha512-2ldT7xEC7KxoaEJ7nCY9/AB/xwPjbm3mrmpiIspT0b5OgS640Pe9EU4c5bSmzGoUbLvwF+jb+LhLE1QaEbWkBw==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/durable-objects": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.12.1.tgz",
+      "integrity": "sha512-/n9WIxvHavVUgT+Nf280wNOcmJQBG+eZuqOlORWW9RmXXbAzqzS2Mk2lmRDCzbq3xTXAcsndx6cdarQLNRUzBg==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/storage-memory": "2.12.1",
+        "undici": "5.20.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/html-rewriter": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.12.1.tgz",
+      "integrity": "sha512-yezYzGRBxy7d/oomAUEftdnL4fq6YIek82LtQlXgzcdcbBDnkYADj8WqGV41tAI+V2+rjrFEc1RuCXx/I1yISw==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "html-rewriter-wasm": "^0.4.1",
+        "undici": "5.20.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/http-server": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.12.1.tgz",
+      "integrity": "sha512-nC6POgDKFHxnyXbKCdR9FGZSsu5frXQUETvSVcoETd5RP+Iws0xZ+XkzVMqiiIZk3ifUC9LzdGUOD0J2PlhHJw==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/web-sockets": "2.12.1",
+        "kleur": "^4.1.4",
+        "selfsigned": "^2.0.0",
+        "undici": "5.20.0",
+        "ws": "^8.2.2",
+        "youch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/kv": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.12.1.tgz",
+      "integrity": "sha512-8h8wLDMEaWaKAqYTwrckOcNjAz52bzDyLmU4t/lh1/AQOE9eSg/T+H6xQCv0fPGrWPeHmG8iXaFI1JQ+CtkcHw==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/shared": "2.12.1"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/queues": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.12.1.tgz",
+      "integrity": "sha512-L/YJkWWvg1RS3sCB5DLZOsf/kAmkwhvshpl+LmGQT7z/PYXlplbBmuhPwVBXaHqZdYE7063XfTzgAIhVPoo72Q==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/shared": "2.12.1"
+      },
+      "engines": {
+        "node": ">=16.7"
+      }
+    },
+    "node_modules/@miniflare/r2": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.12.1.tgz",
+      "integrity": "sha512-xp8fSSap6o5xSAWp9BtOGgZ4tuf5iHTqrfbAH66LF151j8y69eQtQJ5pxpSvrDJok/F1VOLGc4ihSLmUqxyXhw==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/shared": "2.12.1",
+        "undici": "5.20.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/runner-vm": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.12.1.tgz",
+      "integrity": "sha512-pGY/aoQzbvyXOGR6/d3hv5/QsyUXGGbOxAyXdvjlz8h7ZiKOX4dBRS5TUAPS0kb/ofUWCyoYJi8dCVwRGdTYRw==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/shared": "2.12.1"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/scheduler": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.12.1.tgz",
+      "integrity": "sha512-AbOP8YpWNqR/t7zMuTmn6q27USCDBQaYaULRVaNNfCsxMTXAUjYfM85iFvnV9mshw+K0HIEU4zR4Xjd2FeJubg==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "cron-schedule": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/shared": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.12.1.tgz",
+      "integrity": "sha512-N8sHNM5vcvjvO+znQ7Mbqf0FChRlWxy/svUpQf1GGpii9aTXzOTWB+WkFvJrJNx44SUReEGxUAzxpdeWnHahmA==",
+      "dev": true,
+      "dependencies": {
+        "@types/better-sqlite3": "^7.6.0",
+        "kleur": "^4.1.4",
+        "npx-import": "^1.1.4",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/sites": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.12.1.tgz",
+      "integrity": "sha512-LW4r82cfGJvmJFwoBdXfsRcdDggVf8ppjMZGU3zk7xo+u5yD1uHzO2Arf3XbKNiOp7f9WyC/mXxs4zxF605iLA==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/kv": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/storage-file": "2.12.1"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/storage-file": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.12.1.tgz",
+      "integrity": "sha512-eq5wzBwxQC5GVxBfji9svb9FRdSOlA8D8DTgzL29DDjuOYtG9j8ydOlo0J7/2MB/Gq0HYFUHYWHhrklzzwdKQQ==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/storage-memory": "2.12.1"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/storage-memory": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.12.1.tgz",
+      "integrity": "sha512-E9jbrX0L9N7YIHXj2G4td1EKboVLBdHkwh7RvKEZBwOhxDze5h+jMOou57NIbfC5kLOZPOC1fGXjzpp7xUUE6w==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/shared": "2.12.1"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/watcher": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.12.1.tgz",
+      "integrity": "sha512-3IG/6g38id5ppbZHB/gMfEvoIEFYdmTTLRsHaPNyWIk/r3LMhHLluVsMcs+Lr/fphkPk6Diou4cBLD2GeeoP7A==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/shared": "2.12.1"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@miniflare/web-sockets": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.12.1.tgz",
+      "integrity": "sha512-Z+zqZqhVdrbmTQf+ETP5H1TPdXC2tUiYPiHRLWTHUks6VVkuwnUtIKxNPBEBXjCjKYYEm8VLclUAt+0yTucLWA==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "undici": "5.20.0",
+        "ws": "^8.2.2"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.3.tgz",
+      "integrity": "sha512-YS64N9SNDT/NAvou3QNdzAu3E2om/W/0dhORimtPGLef+zSK5l1vDzfsWb4xgXOgfhtOI5ZDTRxnvRPb22AIVQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.15.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.5.tgz",
+      "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==",
+      "dev": true
+    },
+    "node_modules/@types/stack-trace": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
+      "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
+      "dev": true
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cron-schedule": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.6.tgz",
+      "integrity": "sha512-izfGgKyzzIyLaeb1EtZ3KbglkS6AKp9cv7LxmiyoOu+fXfol1tQDC0Cof0enVZGNtudTHW+3lfuW9ZkLQss4Wg==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.3.tgz",
+      "integrity": "sha512-71f7EjPWTiSguen8X/kxEpkAS7BFHwtQKisCDDV3Y4GLGWBaoSCyD5uXkaUew6JDzA9FEN1W23mdnSwW9kqCeg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.16.3",
+        "@esbuild/android-arm64": "0.16.3",
+        "@esbuild/android-x64": "0.16.3",
+        "@esbuild/darwin-arm64": "0.16.3",
+        "@esbuild/darwin-x64": "0.16.3",
+        "@esbuild/freebsd-arm64": "0.16.3",
+        "@esbuild/freebsd-x64": "0.16.3",
+        "@esbuild/linux-arm": "0.16.3",
+        "@esbuild/linux-arm64": "0.16.3",
+        "@esbuild/linux-ia32": "0.16.3",
+        "@esbuild/linux-loong64": "0.16.3",
+        "@esbuild/linux-mips64el": "0.16.3",
+        "@esbuild/linux-ppc64": "0.16.3",
+        "@esbuild/linux-riscv64": "0.16.3",
+        "@esbuild/linux-s390x": "0.16.3",
+        "@esbuild/linux-x64": "0.16.3",
+        "@esbuild/netbsd-x64": "0.16.3",
+        "@esbuild/openbsd-x64": "0.16.3",
+        "@esbuild/sunos-x64": "0.16.3",
+        "@esbuild/win32-arm64": "0.16.3",
+        "@esbuild/win32-ia32": "0.16.3",
+        "@esbuild/win32-x64": "0.16.3"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
+    },
+    "node_modules/execa": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^3.0.1",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/hono": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-3.1.2.tgz",
+      "integrity": "sha512-keNMGSlBX2VbwD5gF10Xu0zuUm9mTy1HWctIhuom8FJEJY6aKo1Bb/vQXTEjBupKDG7MJi2aG05YMo01GjkMQA==",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/html-rewriter-wasm": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/html-rewriter-wasm/-/html-rewriter-wasm-0.4.1.tgz",
+      "integrity": "sha512-lNovG8CMCCmcVB1Q7xggMSf7tqPCijZXaH4gL6iE8BFghdQCbaY5Met9i1x2Ex8m/cZHDUtXK9H6/znKamRP8Q==",
+      "dev": true
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "dev": true
+    },
+    "node_modules/human-signals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isbot": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.6.7.tgz",
+      "integrity": "sha512-SXNUQaNZlj/+9jdrGnAp6WW0YoHe3MIwwc6oRIYuhhERBUt7/L6I7JkMiA2sX9fcvS7gZ2C7GWgmDZfOOU4I5g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.12.1.tgz",
+      "integrity": "sha512-pym6gzg8AQZ1NRChRV1hC4K55N49wndoaDEVRMvZPJrFsmGkNnXkWmlvmZ7SB3BN5UkP5MZwKhLqiJ49Ry8tFA==",
+      "dev": true,
+      "dependencies": {
+        "@miniflare/cache": "2.12.1",
+        "@miniflare/cli-parser": "2.12.1",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/d1": "2.12.1",
+        "@miniflare/durable-objects": "2.12.1",
+        "@miniflare/html-rewriter": "2.12.1",
+        "@miniflare/http-server": "2.12.1",
+        "@miniflare/kv": "2.12.1",
+        "@miniflare/queues": "2.12.1",
+        "@miniflare/r2": "2.12.1",
+        "@miniflare/runner-vm": "2.12.1",
+        "@miniflare/scheduler": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/sites": "2.12.1",
+        "@miniflare/storage-file": "2.12.1",
+        "@miniflare/storage-memory": "2.12.1",
+        "@miniflare/web-sockets": "2.12.1",
+        "kleur": "^4.1.4",
+        "semiver": "^1.1.0",
+        "source-map-support": "^0.5.20",
+        "undici": "5.20.0"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "@miniflare/storage-redis": "2.12.1",
+        "cron-schedule": "^3.0.4",
+        "ioredis": "^4.27.9"
+      },
+      "peerDependenciesMeta": {
+        "@miniflare/storage-redis": {
+          "optional": true
+        },
+        "cron-schedule": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npx-import": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/npx-import/-/npx-import-1.1.4.tgz",
+      "integrity": "sha512-3ShymTWOgqGyNlh5lMJAejLuIv3W1K3fbI5Ewc6YErZU3Sp0PqsNs8UIU1O8z5+KVl/Du5ag56Gza9vdorGEoA==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^6.1.0",
+        "parse-package-name": "^1.0.0",
+        "semver": "^7.3.7",
+        "validate-npm-package-name": "^4.0.0"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-package-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-package-name/-/parse-package-name-1.0.0.tgz",
+      "integrity": "sha512-kBeTUtcj+SkyfaW4+KBe0HtsloBJ/mKTPoxpVdA57GZiPerREsUWJOhVj9anXweFiJkm5y8FG1sxFZkZ0SN6wg==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/selfsigned": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
+      "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
+      "dev": true,
+      "dependencies": {
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semiver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semiver/-/semiver-1.1.0.tgz",
+      "integrity": "sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
+      "dev": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-4.0.3.tgz",
+      "integrity": "sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==",
+      "dev": true
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz",
+      "integrity": "sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==",
+      "dev": true,
+      "dependencies": {
+        "builtins": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.13.0.tgz",
+      "integrity": "sha512-hU7RpOjDcyOlKO0xuNEOKINwSA1lh5nSkTH8aKKdatv2Ryt5gSS26RwS49QpZCYJGxGHzhHPr++TlSggOAsEVA==",
+      "dev": true,
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "^0.2.0",
+        "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
+        "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/d1": "2.12.1",
+        "@miniflare/durable-objects": "2.12.1",
+        "blake3-wasm": "^2.1.5",
+        "chokidar": "^3.5.3",
+        "esbuild": "0.16.3",
+        "miniflare": "2.12.1",
+        "nanoid": "^3.3.3",
+        "path-to-regexp": "^6.2.0",
+        "selfsigned": "^2.0.1",
+        "source-map": "^0.7.4",
+        "xxhash-wasm": "^1.0.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.0.2.tgz",
+      "integrity": "sha512-ibF0Or+FivM9lNrg+HGJfVX8WJqgo+kCLDc4vx6xMeTce7Aj+DLttKbxxRR/gNLSAelRc1omAPlJ77N/Jem07A==",
+      "dev": true
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/youch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-2.2.2.tgz",
+      "integrity": "sha512-/FaCeG3GkuJwaMR34GHVg0l8jCbafZLHiFowSjqLlqhC6OMyf2tPJBu8UirF7/NI9X/R5ai4QfEKUCOxMAGxZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/stack-trace": "0.0.29",
+        "cookie": "^0.4.1",
+        "mustache": "^4.2.0",
+        "stack-trace": "0.0.10"
+      }
+    }
+  },
+  "dependencies": {
+    "@cloudflare/kv-asset-handler": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.2.0.tgz",
+      "integrity": "sha512-MVbXLbTcAotOPUj0pAMhVtJ+3/kFkwJqc5qNOleOZTv6QkZZABDMS21dSrSlVswEHwrpWC03e4fWytjqKvuE2A==",
+      "dev": true,
+      "requires": {
+        "mime": "^3.0.0"
+      }
+    },
+    "@cloudflare/workers-types": {
+      "version": "4.20230321.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20230321.0.tgz",
+      "integrity": "sha512-zyRFz9AUS0tbg3/kJ+3zxvp9fl/O9yOJlChih/o86hhOqRMcZVbWefYAvFPidRvYUHM5YTG1wjU1bF9FFckRVg==",
+      "dev": true
+    },
+    "@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.1.1.tgz",
+      "integrity": "sha512-MR0oAA+mlnJWrt1RQVQ+4VYuRJW/P2YmRTv1AsplObyvuBMnPHiizUF95HHYiSsMGLhyGtWufaq2XQg6+iurBg==",
+      "dev": true,
+      "requires": {}
+    },
+    "@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.1.4.tgz",
+      "integrity": "sha512-uZbcXi0zbmKC/050p3gJnne5Qdzw8vkXIv+c2BW0Lsc1ji1SkrxbKPUy5Efr0blbTu1SL8w4eyfpnSdPg3G0Qg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      }
+    },
+    "@esbuild/android-arm": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.3.tgz",
+      "integrity": "sha512-mueuEoh+s1eRbSJqq9KNBQwI4QhQV6sRXIfTyLXSHGMpyew61rOK4qY21uKbXl1iBoMb0AdL1deWFCQVlN2qHA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.3.tgz",
+      "integrity": "sha512-RolFVeinkeraDvN/OoRf1F/lP0KUfGNb5jxy/vkIMeRRChkrX/HTYN6TYZosRJs3a1+8wqpxAo5PI5hFmxyPRg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.3.tgz",
+      "integrity": "sha512-SFpTUcIT1bIJuCCBMCQWq1bL2gPTjWoLZdjmIhjdcQHaUfV41OQfho6Ici5uvvkMmZRXIUGpM3GxysP/EU7ifQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.3.tgz",
+      "integrity": "sha512-DO8WykMyB+N9mIDfI/Hug70Dk1KipavlGAecxS3jDUwAbTpDXj0Lcwzw9svkhxfpCagDmpaTMgxWK8/C/XcXvw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.3.tgz",
+      "integrity": "sha512-uEqZQ2omc6BvWqdCiyZ5+XmxuHEi1SPzpVxXCSSV2+Sh7sbXbpeNhHIeFrIpRjAs0lI1FmA1iIOxFozKBhKgRQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.3.tgz",
+      "integrity": "sha512-nJansp3sSXakNkOD5i5mIz2Is/HjzIhFs49b1tjrPrpCmwgBmH9SSzhC/Z1UqlkivqMYkhfPwMw1dGFUuwmXhw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.3.tgz",
+      "integrity": "sha512-TfoDzLw+QHfc4a8aKtGSQ96Wa+6eimljjkq9HKR0rHlU83vw8aldMOUSJTUDxbcUdcgnJzPaX8/vGWm7vyV7ug==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.3.tgz",
+      "integrity": "sha512-VwswmSYwVAAq6LysV59Fyqk3UIjbhuc6wb3vEcJ7HEJUtFuLK9uXWuFoH1lulEbE4+5GjtHi3MHX+w1gNHdOWQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.3.tgz",
+      "integrity": "sha512-7I3RlsnxEFCHVZNBLb2w7unamgZ5sVwO0/ikE2GaYvYuUQs9Qte/w7TqWcXHtCwxvZx/2+F97ndiUQAWs47ZfQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.3.tgz",
+      "integrity": "sha512-X8FDDxM9cqda2rJE+iblQhIMYY49LfvW4kaEjoFbTTQ4Go8G96Smj2w3BRTwA8IHGoi9dPOPGAX63dhuv19UqA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.3.tgz",
+      "integrity": "sha512-hIbeejCOyO0X9ujfIIOKjBjNAs9XD/YdJ9JXAy1lHA+8UXuOqbFe4ErMCqMr8dhlMGBuvcQYGF7+kO7waj2KHw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.3.tgz",
+      "integrity": "sha512-znFRzICT/V8VZQMt6rjb21MtAVJv/3dmKRMlohlShrbVXdBuOdDrGb+C2cZGQAR8RFyRe7HS6klmHq103WpmVw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.3.tgz",
+      "integrity": "sha512-EV7LuEybxhXrVTDpbqWF2yehYRNz5e5p+u3oQUS2+ZFpknyi1NXxr8URk4ykR8Efm7iu04//4sBg249yNOwy5Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.3.tgz",
+      "integrity": "sha512-uDxqFOcLzFIJ+r/pkTTSE9lsCEaV/Y6rMlQjUI9BkzASEChYL/aSQjZjchtEmdnVxDKETnUAmsaZ4pqK1eE5BQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.3.tgz",
+      "integrity": "sha512-NbeREhzSxYwFhnCAQOQZmajsPYtX71Ufej3IQ8W2Gxskfz9DK58ENEju4SbpIj48VenktRASC52N5Fhyf/aliQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.3.tgz",
+      "integrity": "sha512-SDiG0nCixYO9JgpehoKgScwic7vXXndfasjnD5DLbp1xltANzqZ425l7LSdHynt19UWOcDjG9wJJzSElsPvk0w==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.3.tgz",
+      "integrity": "sha512-AzbsJqiHEq1I/tUvOfAzCY15h4/7Ivp3ff/o1GpP16n48JMNAtbW0qui2WCgoIZArEHD0SUQ95gvR0oSO7ZbdA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.3.tgz",
+      "integrity": "sha512-gSABi8qHl8k3Cbi/4toAzHiykuBuWLZs43JomTcXkjMZVkp0gj3gg9mO+9HJW/8GB5H89RX/V0QP4JGL7YEEVg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.3.tgz",
+      "integrity": "sha512-SF9Kch5Ete4reovvRO6yNjMxrvlfT0F0Flm+NPoUw5Z4Q3r1d23LFTgaLwm3Cp0iGbrU/MoUI+ZqwCv5XJijCw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.3.tgz",
+      "integrity": "sha512-u5aBonZIyGopAZyOnoPAA6fGsDeHByZ9CnEzyML9NqntK6D/xl5jteZUKm/p6nD09+v3pTM6TuUIqSPcChk5gg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.3.tgz",
+      "integrity": "sha512-GlgVq1WpvOEhNioh74TKelwla9KDuAaLZrdxuuUgsP2vayxeLgVc+rbpIv0IYF4+tlIzq2vRhofV+KGLD+37EQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.3.tgz",
+      "integrity": "sha512-5/JuTd8OWW8UzEtyf19fbrtMJENza+C9JoPIkvItgTBQ1FO2ZLvjbPO6Xs54vk0s5JB5QsfieUEshRQfu7ZHow==",
+      "dev": true,
+      "optional": true
+    },
+    "@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "dev": true
+    },
+    "@miniflare/cache": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.12.1.tgz",
+      "integrity": "sha512-6Pj5avy53qULTa13gWxGTDBuwX0yAzr4Zkzb0ZBh40bcbHp4vRkOk7PvHBoxV0M76JxQDHotGaW+ik510z5Xrg==",
+      "dev": true,
+      "requires": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "http-cache-semantics": "^4.1.0",
+        "undici": "5.20.0"
+      }
+    },
+    "@miniflare/cli-parser": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.12.1.tgz",
+      "integrity": "sha512-iCh4wEyQow8Dha+zpKhjCCXEp6QWbsvE18H5CgeUFT1pX4B+akYIHzdn47Cr5zpuYyjenoL78bAz0IIHIeyeWw==",
+      "dev": true,
+      "requires": {
+        "@miniflare/shared": "2.12.1",
+        "kleur": "^4.1.4"
+      }
+    },
+    "@miniflare/core": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.12.1.tgz",
+      "integrity": "sha512-729xXL6uoMgtja5J7B2WdWAjFfxb74Pk2QqM3VqkWqY3XNlKWI7+ofvb8S6kI6uFEPGj4ma263uYkEAgsvzBWg==",
+      "dev": true,
+      "requires": {
+        "@iarna/toml": "^2.2.5",
+        "@miniflare/queues": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/watcher": "2.12.1",
+        "busboy": "^1.6.0",
+        "dotenv": "^10.0.0",
+        "kleur": "^4.1.4",
+        "set-cookie-parser": "^2.4.8",
+        "undici": "5.20.0",
+        "urlpattern-polyfill": "^4.0.3"
+      }
+    },
+    "@miniflare/d1": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.12.1.tgz",
+      "integrity": "sha512-2ldT7xEC7KxoaEJ7nCY9/AB/xwPjbm3mrmpiIspT0b5OgS640Pe9EU4c5bSmzGoUbLvwF+jb+LhLE1QaEbWkBw==",
+      "dev": true,
+      "requires": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1"
+      }
+    },
+    "@miniflare/durable-objects": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.12.1.tgz",
+      "integrity": "sha512-/n9WIxvHavVUgT+Nf280wNOcmJQBG+eZuqOlORWW9RmXXbAzqzS2Mk2lmRDCzbq3xTXAcsndx6cdarQLNRUzBg==",
+      "dev": true,
+      "requires": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/storage-memory": "2.12.1",
+        "undici": "5.20.0"
+      }
+    },
+    "@miniflare/html-rewriter": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.12.1.tgz",
+      "integrity": "sha512-yezYzGRBxy7d/oomAUEftdnL4fq6YIek82LtQlXgzcdcbBDnkYADj8WqGV41tAI+V2+rjrFEc1RuCXx/I1yISw==",
+      "dev": true,
+      "requires": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "html-rewriter-wasm": "^0.4.1",
+        "undici": "5.20.0"
+      }
+    },
+    "@miniflare/http-server": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.12.1.tgz",
+      "integrity": "sha512-nC6POgDKFHxnyXbKCdR9FGZSsu5frXQUETvSVcoETd5RP+Iws0xZ+XkzVMqiiIZk3ifUC9LzdGUOD0J2PlhHJw==",
+      "dev": true,
+      "requires": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/web-sockets": "2.12.1",
+        "kleur": "^4.1.4",
+        "selfsigned": "^2.0.0",
+        "undici": "5.20.0",
+        "ws": "^8.2.2",
+        "youch": "^2.2.2"
+      }
+    },
+    "@miniflare/kv": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.12.1.tgz",
+      "integrity": "sha512-8h8wLDMEaWaKAqYTwrckOcNjAz52bzDyLmU4t/lh1/AQOE9eSg/T+H6xQCv0fPGrWPeHmG8iXaFI1JQ+CtkcHw==",
+      "dev": true,
+      "requires": {
+        "@miniflare/shared": "2.12.1"
+      }
+    },
+    "@miniflare/queues": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.12.1.tgz",
+      "integrity": "sha512-L/YJkWWvg1RS3sCB5DLZOsf/kAmkwhvshpl+LmGQT7z/PYXlplbBmuhPwVBXaHqZdYE7063XfTzgAIhVPoo72Q==",
+      "dev": true,
+      "requires": {
+        "@miniflare/shared": "2.12.1"
+      }
+    },
+    "@miniflare/r2": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.12.1.tgz",
+      "integrity": "sha512-xp8fSSap6o5xSAWp9BtOGgZ4tuf5iHTqrfbAH66LF151j8y69eQtQJ5pxpSvrDJok/F1VOLGc4ihSLmUqxyXhw==",
+      "dev": true,
+      "requires": {
+        "@miniflare/shared": "2.12.1",
+        "undici": "5.20.0"
+      }
+    },
+    "@miniflare/runner-vm": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.12.1.tgz",
+      "integrity": "sha512-pGY/aoQzbvyXOGR6/d3hv5/QsyUXGGbOxAyXdvjlz8h7ZiKOX4dBRS5TUAPS0kb/ofUWCyoYJi8dCVwRGdTYRw==",
+      "dev": true,
+      "requires": {
+        "@miniflare/shared": "2.12.1"
+      }
+    },
+    "@miniflare/scheduler": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.12.1.tgz",
+      "integrity": "sha512-AbOP8YpWNqR/t7zMuTmn6q27USCDBQaYaULRVaNNfCsxMTXAUjYfM85iFvnV9mshw+K0HIEU4zR4Xjd2FeJubg==",
+      "dev": true,
+      "requires": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "cron-schedule": "^3.0.4"
+      }
+    },
+    "@miniflare/shared": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.12.1.tgz",
+      "integrity": "sha512-N8sHNM5vcvjvO+znQ7Mbqf0FChRlWxy/svUpQf1GGpii9aTXzOTWB+WkFvJrJNx44SUReEGxUAzxpdeWnHahmA==",
+      "dev": true,
+      "requires": {
+        "@types/better-sqlite3": "^7.6.0",
+        "kleur": "^4.1.4",
+        "npx-import": "^1.1.4",
+        "picomatch": "^2.3.1"
+      }
+    },
+    "@miniflare/sites": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.12.1.tgz",
+      "integrity": "sha512-LW4r82cfGJvmJFwoBdXfsRcdDggVf8ppjMZGU3zk7xo+u5yD1uHzO2Arf3XbKNiOp7f9WyC/mXxs4zxF605iLA==",
+      "dev": true,
+      "requires": {
+        "@miniflare/kv": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/storage-file": "2.12.1"
+      }
+    },
+    "@miniflare/storage-file": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.12.1.tgz",
+      "integrity": "sha512-eq5wzBwxQC5GVxBfji9svb9FRdSOlA8D8DTgzL29DDjuOYtG9j8ydOlo0J7/2MB/Gq0HYFUHYWHhrklzzwdKQQ==",
+      "dev": true,
+      "requires": {
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/storage-memory": "2.12.1"
+      }
+    },
+    "@miniflare/storage-memory": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.12.1.tgz",
+      "integrity": "sha512-E9jbrX0L9N7YIHXj2G4td1EKboVLBdHkwh7RvKEZBwOhxDze5h+jMOou57NIbfC5kLOZPOC1fGXjzpp7xUUE6w==",
+      "dev": true,
+      "requires": {
+        "@miniflare/shared": "2.12.1"
+      }
+    },
+    "@miniflare/watcher": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.12.1.tgz",
+      "integrity": "sha512-3IG/6g38id5ppbZHB/gMfEvoIEFYdmTTLRsHaPNyWIk/r3LMhHLluVsMcs+Lr/fphkPk6Diou4cBLD2GeeoP7A==",
+      "dev": true,
+      "requires": {
+        "@miniflare/shared": "2.12.1"
+      }
+    },
+    "@miniflare/web-sockets": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.12.1.tgz",
+      "integrity": "sha512-Z+zqZqhVdrbmTQf+ETP5H1TPdXC2tUiYPiHRLWTHUks6VVkuwnUtIKxNPBEBXjCjKYYEm8VLclUAt+0yTucLWA==",
+      "dev": true,
+      "requires": {
+        "@miniflare/core": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "undici": "5.20.0",
+        "ws": "^8.2.2"
+      }
+    },
+    "@types/better-sqlite3": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.3.tgz",
+      "integrity": "sha512-YS64N9SNDT/NAvou3QNdzAu3E2om/W/0dhORimtPGLef+zSK5l1vDzfsWb4xgXOgfhtOI5ZDTRxnvRPb22AIVQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "18.15.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.5.tgz",
+      "integrity": "sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==",
+      "dev": true
+    },
+    "@types/stack-trace": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
+      "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.0.0"
+      }
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
+    },
+    "cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true
+    },
+    "cron-schedule": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-3.0.6.tgz",
+      "integrity": "sha512-izfGgKyzzIyLaeb1EtZ3KbglkS6AKp9cv7LxmiyoOu+fXfol1tQDC0Cof0enVZGNtudTHW+3lfuW9ZkLQss4Wg==",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true
+    },
+    "esbuild": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.3.tgz",
+      "integrity": "sha512-71f7EjPWTiSguen8X/kxEpkAS7BFHwtQKisCDDV3Y4GLGWBaoSCyD5uXkaUew6JDzA9FEN1W23mdnSwW9kqCeg==",
+      "dev": true,
+      "requires": {
+        "@esbuild/android-arm": "0.16.3",
+        "@esbuild/android-arm64": "0.16.3",
+        "@esbuild/android-x64": "0.16.3",
+        "@esbuild/darwin-arm64": "0.16.3",
+        "@esbuild/darwin-x64": "0.16.3",
+        "@esbuild/freebsd-arm64": "0.16.3",
+        "@esbuild/freebsd-x64": "0.16.3",
+        "@esbuild/linux-arm": "0.16.3",
+        "@esbuild/linux-arm64": "0.16.3",
+        "@esbuild/linux-ia32": "0.16.3",
+        "@esbuild/linux-loong64": "0.16.3",
+        "@esbuild/linux-mips64el": "0.16.3",
+        "@esbuild/linux-ppc64": "0.16.3",
+        "@esbuild/linux-riscv64": "0.16.3",
+        "@esbuild/linux-s390x": "0.16.3",
+        "@esbuild/linux-x64": "0.16.3",
+        "@esbuild/netbsd-x64": "0.16.3",
+        "@esbuild/openbsd-x64": "0.16.3",
+        "@esbuild/sunos-x64": "0.16.3",
+        "@esbuild/win32-arm64": "0.16.3",
+        "@esbuild/win32-ia32": "0.16.3",
+        "@esbuild/win32-x64": "0.16.3"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
+    },
+    "execa": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^3.0.1",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "hono": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-3.1.2.tgz",
+      "integrity": "sha512-keNMGSlBX2VbwD5gF10Xu0zuUm9mTy1HWctIhuom8FJEJY6aKo1Bb/vQXTEjBupKDG7MJi2aG05YMo01GjkMQA=="
+    },
+    "html-rewriter-wasm": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/html-rewriter-wasm/-/html-rewriter-wasm-0.4.1.tgz",
+      "integrity": "sha512-lNovG8CMCCmcVB1Q7xggMSf7tqPCijZXaH4gL6iE8BFghdQCbaY5Met9i1x2Ex8m/cZHDUtXK9H6/znKamRP8Q==",
+      "dev": true
+    },
+    "http-cache-semantics": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "dev": true
+    },
+    "human-signals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true
+    },
+    "isbot": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-3.6.7.tgz",
+      "integrity": "sha512-SXNUQaNZlj/+9jdrGnAp6WW0YoHe3MIwwc6oRIYuhhERBUt7/L6I7JkMiA2sX9fcvS7gZ2C7GWgmDZfOOU4I5g=="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true
+    },
+    "mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true
+    },
+    "miniflare": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.12.1.tgz",
+      "integrity": "sha512-pym6gzg8AQZ1NRChRV1hC4K55N49wndoaDEVRMvZPJrFsmGkNnXkWmlvmZ7SB3BN5UkP5MZwKhLqiJ49Ry8tFA==",
+      "dev": true,
+      "requires": {
+        "@miniflare/cache": "2.12.1",
+        "@miniflare/cli-parser": "2.12.1",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/d1": "2.12.1",
+        "@miniflare/durable-objects": "2.12.1",
+        "@miniflare/html-rewriter": "2.12.1",
+        "@miniflare/http-server": "2.12.1",
+        "@miniflare/kv": "2.12.1",
+        "@miniflare/queues": "2.12.1",
+        "@miniflare/r2": "2.12.1",
+        "@miniflare/runner-vm": "2.12.1",
+        "@miniflare/scheduler": "2.12.1",
+        "@miniflare/shared": "2.12.1",
+        "@miniflare/sites": "2.12.1",
+        "@miniflare/storage-file": "2.12.1",
+        "@miniflare/storage-memory": "2.12.1",
+        "@miniflare/web-sockets": "2.12.1",
+        "kleur": "^4.1.4",
+        "semiver": "^1.1.0",
+        "source-map-support": "^0.5.20",
+        "undici": "5.20.0"
+      }
+    },
+    "mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true
+    },
+    "node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "requires": {
+        "path-key": "^4.0.0"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        }
+      }
+    },
+    "npx-import": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/npx-import/-/npx-import-1.1.4.tgz",
+      "integrity": "sha512-3ShymTWOgqGyNlh5lMJAejLuIv3W1K3fbI5Ewc6YErZU3Sp0PqsNs8UIU1O8z5+KVl/Du5ag56Gza9vdorGEoA==",
+      "dev": true,
+      "requires": {
+        "execa": "^6.1.0",
+        "parse-package-name": "^1.0.0",
+        "semver": "^7.3.7",
+        "validate-npm-package-name": "^4.0.0"
+      }
+    },
+    "onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^4.0.0"
+      }
+    },
+    "parse-package-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-package-name/-/parse-package-name-1.0.0.tgz",
+      "integrity": "sha512-kBeTUtcj+SkyfaW4+KBe0HtsloBJ/mKTPoxpVdA57GZiPerREsUWJOhVj9anXweFiJkm5y8FG1sxFZkZ0SN6wg==",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "requires": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "selfsigned": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
+      "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
+      "dev": true,
+      "requires": {
+        "node-forge": "^1"
+      }
+    },
+    "semiver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semiver/-/semiver-1.1.0.tgz",
+      "integrity": "sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "dev": true
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "undici": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
+      "dev": true,
+      "requires": {
+        "busboy": "^1.6.0"
+      }
+    },
+    "urlpattern-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-4.0.3.tgz",
+      "integrity": "sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ==",
+      "dev": true
+    },
+    "validate-npm-package-name": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz",
+      "integrity": "sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==",
+      "dev": true,
+      "requires": {
+        "builtins": "^5.0.0"
+      }
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wrangler": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.13.0.tgz",
+      "integrity": "sha512-hU7RpOjDcyOlKO0xuNEOKINwSA1lh5nSkTH8aKKdatv2Ryt5gSS26RwS49QpZCYJGxGHzhHPr++TlSggOAsEVA==",
+      "dev": true,
+      "requires": {
+        "@cloudflare/kv-asset-handler": "^0.2.0",
+        "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
+        "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
+        "@miniflare/core": "2.12.1",
+        "@miniflare/d1": "2.12.1",
+        "@miniflare/durable-objects": "2.12.1",
+        "blake3-wasm": "^2.1.5",
+        "chokidar": "^3.5.3",
+        "esbuild": "0.16.3",
+        "fsevents": "~2.3.2",
+        "miniflare": "2.12.1",
+        "nanoid": "^3.3.3",
+        "path-to-regexp": "^6.2.0",
+        "selfsigned": "^2.0.1",
+        "source-map": "^0.7.4",
+        "xxhash-wasm": "^1.0.1"
+      }
+    },
+    "ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "dev": true,
+      "requires": {}
+    },
+    "xxhash-wasm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.0.2.tgz",
+      "integrity": "sha512-ibF0Or+FivM9lNrg+HGJfVX8WJqgo+kCLDc4vx6xMeTce7Aj+DLttKbxxRR/gNLSAelRc1omAPlJ77N/Jem07A==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "youch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-2.2.2.tgz",
+      "integrity": "sha512-/FaCeG3GkuJwaMR34GHVg0l8jCbafZLHiFowSjqLlqhC6OMyf2tPJBu8UirF7/NI9X/R5ai4QfEKUCOxMAGxZQ==",
+      "dev": true,
+      "requires": {
+        "@types/stack-trace": "0.0.29",
+        "cookie": "^0.4.1",
+        "mustache": "^4.2.0",
+        "stack-trace": "0.0.10"
+      }
+    }
+  }
+}

--- a/ssr-opengraph/package.json
+++ b/ssr-opengraph/package.json
@@ -4,6 +4,10 @@
     "dev": "wrangler dev src/index.tsx"
   },
   "dependencies": {
+    "@kodadot1/minipfs": "0.2.0-rc.0",
+    "@kodadot1/static": "0.0.1-rc.0",
+    "@kodadot1/uniquery": "0.2.2-rc.0",
+    "@polkadot/util": "^11.1.1",
     "hono": "^3.1.2",
     "isbot": "^3.6.7"
   },

--- a/ssr-opengraph/package.json
+++ b/ssr-opengraph/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "deploy": "wrangler publish src/index.tsx",
+    "dev": "wrangler dev src/index.tsx"
+  },
+  "dependencies": {
+    "hono": "^3.1.2",
+    "isbot": "^3.6.7"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20230307.0",
+    "wrangler": "^2.13.0"
+  }
+}

--- a/ssr-opengraph/src/index.tsx
+++ b/ssr-opengraph/src/index.tsx
@@ -3,6 +3,7 @@ import isbot from 'isbot';
 import { Opengraph } from './template';
 import { formatPrice, getNftById, getProperties } from './utils';
 
+import type { Chain } from './utils';
 import type { NFTEntity } from './types';
 
 const app = new Hono();
@@ -22,17 +23,15 @@ app.get('/:chain/gallery/:id', async (c) => {
   const id = c.req.param('id');
 
   if (chain === 'bsx' || chain === 'rmrk' || chain === 'snek') {
-    const response = await getNftById(chain, id);
+    const response = await getNftById(chain as Chain, id);
     const data = (await response.json()) as NFTEntity;
-    const { nftEntityById } = data.data;
+    const { item } = data.data;
 
     const canonical = `https://kodadot.xyz/${chain}/gallery/${id}`;
-    const { name, description, title, cdn } = await getProperties(
-      nftEntityById
-    );
+    const { name, description, title, cdn } = await getProperties(item);
 
     // contruct price
-    const price = formatPrice(nftEntityById.price);
+    const price = formatPrice(item.price);
 
     // construct vercel image with cdn
     const image = new URL(

--- a/ssr-opengraph/src/index.tsx
+++ b/ssr-opengraph/src/index.tsx
@@ -3,7 +3,7 @@ import isbot from 'isbot';
 import { Opengraph } from './template';
 import { formatPrice, getNftById, getProperties } from './utils';
 
-import type { Chain } from './utils';
+import type { Chains } from './utils';
 import type { NFTEntity } from './types';
 
 const app = new Hono();
@@ -23,8 +23,8 @@ app.get('/:chain/gallery/:id', async (c) => {
   const id = c.req.param('id');
 
   if (chain === 'bsx' || chain === 'rmrk' || chain === 'snek') {
-    const response = await getNftById(chain as Chain, id);
-    const data = (await response.json()) as NFTEntity;
+    const response = await getNftById(chain as Chains, id);
+    const data = response as NFTEntity;
     const { item } = data.data;
 
     const canonical = `https://kodadot.xyz/${chain}/gallery/${id}`;

--- a/ssr-opengraph/src/index.tsx
+++ b/ssr-opengraph/src/index.tsx
@@ -1,0 +1,60 @@
+import { Hono } from 'hono';
+import isbot from 'isbot';
+import { Opengraph } from './template';
+import { formatPrice, getNftById, getProperties } from './utils';
+
+import type { NFTEntity } from './types';
+
+const app = new Hono();
+
+app.get('/', (c) => {
+  return c.text('hello hono.js');
+});
+
+app.get('/:chain/gallery/:id', async (c) => {
+  const useragent = c.req.headers.get('user-agent');
+
+  if (useragent && !isbot(useragent)) {
+    return fetch(c.req.url);
+  }
+
+  const chain = c.req.param('chain');
+  const id = c.req.param('id');
+
+  if (chain === 'bsx' || chain === 'rmrk' || chain === 'snek') {
+    const response = await getNftById(chain, id);
+    const data = (await response.json()) as NFTEntity;
+    const { nftEntityById } = data.data;
+
+    const canonical = `https://kodadot.xyz/${chain}/gallery/${id}`;
+    const { name, description, title, cdn } = await getProperties(
+      nftEntityById
+    );
+
+    // contruct price
+    const price = formatPrice(nftEntityById.price);
+
+    // construct vercel image with cdn
+    const image = new URL(
+      `https://og-image-green-seven.vercel.app/${name}.jpeg`
+    );
+    image.searchParams.set('price', price);
+    image.searchParams.set('image', cdn);
+
+    const props = {
+      name: `${chain} ${id}`,
+      siteData: {
+        title,
+        description: description,
+        canonical,
+        image: image.toString(),
+      },
+    };
+
+    return c.html(<Opengraph {...props} />);
+  }
+
+  return fetch(c.req.url);
+});
+
+export default app;

--- a/ssr-opengraph/src/template.tsx
+++ b/ssr-opengraph/src/template.tsx
@@ -1,0 +1,45 @@
+import { html } from 'hono/html';
+
+interface SiteData {
+  children?: any;
+  title: string;
+  description: string;
+  canonical: string;
+  image: string;
+}
+
+export const Layout = (props: SiteData) => html`
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <title>${props.title}</title>
+
+      <link rel="canonical" href="${props.canonical}" />
+
+      <meta name="description" content="${props.description}" />
+
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content="${props.canonical}" />
+      <meta
+        property="og:site_name"
+        content="KodaDot - Polkadot / Kusama NFT explorer"
+      />
+      <meta property="og:title" content="${props.title}" />
+      <meta property="og:description" content="${props.description}" />
+      <meta property="og:image" content="${props.image}" />
+
+      <meta name="twitter:card" content="summary_large_image" />
+    </head>
+
+    <body>
+      ${props.children}
+    </body>
+  </html>
+`;
+
+export const Opengraph = (props: { siteData: SiteData; name: string }) => (
+  <Layout {...props.siteData}>
+    <h1>{props.siteData.title}</h1>
+    <img src={props.siteData.image} alt={props.siteData.title} />
+  </Layout>
+);

--- a/ssr-opengraph/src/types.ts
+++ b/ssr-opengraph/src/types.ts
@@ -1,0 +1,21 @@
+export interface NFTMeta {
+  name: string;
+  image: string;
+  animationUrl: string;
+  description: string;
+  id: string;
+}
+
+export interface NFT {
+  id: string;
+  name: string;
+  price: string;
+  metadata: string;
+  meta?: NFTMeta;
+}
+
+export interface NFTEntity {
+  data: {
+    nftEntityById: NFT;
+  };
+}

--- a/ssr-opengraph/src/types.ts
+++ b/ssr-opengraph/src/types.ts
@@ -1,21 +1,25 @@
 export interface NFTMeta {
+  id: string;
   name: string;
+  description: string;
   image: string;
   animationUrl: string;
-  description: string;
-  id: string;
+  type: null | string;
 }
 
 export interface NFT {
   id: string;
+  createdAt: string;
   name: string;
-  price: string;
   metadata: string;
+  currentOwner: string;
+  issuer: string;
   meta?: NFTMeta;
+  price: string;
 }
 
 export interface NFTEntity {
   data: {
-    nftEntityById: NFT;
+    item: NFT;
   };
 }

--- a/ssr-opengraph/src/utils.ts
+++ b/ssr-opengraph/src/utils.ts
@@ -1,0 +1,79 @@
+import type { NFT, NFTMeta } from './types';
+
+type Chain = 'bsx' | 'rmrk' | 'snek';
+
+export const endpoints: Record<Chain, string> = {
+  bsx: 'https://squid.subsquid.io/snekk/v/005/graphql',
+  snek: 'https://squid.subsquid.io/snekk/v/004/graphql',
+  rmrk: 'https://squid.subsquid.io/rubick/graphql',
+};
+
+export const getNftById = async (chain: Chain, id: string) => {
+  return await fetch(endpoints[chain], {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: `
+          query NftById {
+            nftEntityById(id: "${id}") {
+              id
+              name
+              price
+              metadata
+              meta {
+                name
+                image
+                animationUrl
+                description
+                id
+              }
+            }
+          }
+        `,
+    }),
+  });
+};
+
+export function ipfsToCdn(ipfs: string) {
+  const ipfsCid = ipfs.split('ipfs:/')[1];
+  const cdn = new URL(ipfsCid, 'https://image.w.kodadot.xyz');
+
+  return cdn.toString();
+}
+
+export function formatPrice(price: string) {
+  const number = price;
+  const numAsNumber = parseFloat(number);
+  const divisor = 1000000000000; // 10^12
+  const convertedValue = numAsNumber / divisor;
+  const ksmValue = convertedValue.toFixed(1);
+  return number === '0' ? '' : `${ksmValue} KSM`;
+}
+
+export async function getProperties(nft: NFT) {
+  if (!nft.meta) {
+    const response = await fetch(ipfsToCdn(nft.metadata));
+    const data = (await response.json()) as NFTMeta;
+
+    return {
+      name: data.name,
+      description: data.description,
+      title: `${data.name} | Low Carbon NFTs`,
+      cdn: ipfsToCdn(data.image),
+    };
+  }
+
+  const name = nft.name;
+  const description = nft.meta?.description;
+  const title = `${name} | Low Carbon NFTs`;
+  const cdn = ipfsToCdn(nft.meta?.image);
+
+  return {
+    name,
+    description,
+    title,
+    cdn,
+  };
+}

--- a/ssr-opengraph/src/utils.ts
+++ b/ssr-opengraph/src/utils.ts
@@ -1,34 +1,18 @@
 import { extendFields, getClient } from '@kodadot1/uniquery';
 import { $purify } from '@kodadot1/minipfs';
 import { formatBalance } from '@polkadot/util';
-import { INDEXERS } from '@kodadot1/static';
 
 import type { Prefix } from '@kodadot1/static';
 import type { NFT, NFTMeta } from './types';
 
-// TODO: put 'rmrk' into Prefix type
-export type Chain = 'rmrk' & Prefix;
+export type Chains = 'rmrk' & Prefix;
 
-export const endpoints: Record<Chain, string> = {
-  bsx: INDEXERS['bsx'],
-  snek: INDEXERS['snek'],
-  rmrk: 'https://squid.subsquid.io/rubick/graphql',
-};
-
-export const getNftById = async (chain: Chain, id: string) => {
-  const client = getClient();
+export const getNftById = async (chain: Chains, id: string) => {
+  const getChain = chain === 'rmrk' ? 'ksm' : chain;
+  const client = getClient(getChain);
   const query = client.itemById(id, extendFields(['meta', 'price']));
 
-  // TODO: indexer for 'rmrk'
-  // return await client.fetch(query);
-
-  return await fetch(endpoints[chain], {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(query),
-  });
+  return await client.fetch(query);
 };
 
 export function ipfsToCdn(ipfs: string) {

--- a/ssr-opengraph/src/utils.ts
+++ b/ssr-opengraph/src/utils.ts
@@ -1,6 +1,7 @@
 import { extendFields, getClient } from '@kodadot1/uniquery';
 import { $purify } from '@kodadot1/minipfs';
 import { formatBalance } from '@polkadot/util';
+import { INDEXERS } from '@kodadot1/static';
 
 import type { Prefix } from '@kodadot1/static';
 import type { NFT, NFTMeta } from './types';
@@ -9,8 +10,8 @@ import type { NFT, NFTMeta } from './types';
 export type Chain = 'rmrk' & Prefix;
 
 export const endpoints: Record<Chain, string> = {
-  bsx: 'https://squid.subsquid.io/snekk/v/005/graphql',
-  snek: 'https://squid.subsquid.io/snekk/v/004/graphql',
+  bsx: INDEXERS['bsx'],
+  snek: INDEXERS['snek'],
   rmrk: 'https://squid.subsquid.io/rubick/graphql',
 };
 

--- a/ssr-opengraph/tsconfig.json
+++ b/ssr-opengraph/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "lib": ["esnext"],
+    "types": ["@cloudflare/workers-types"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx"
+  }
+}

--- a/ssr-opengraph/wrangler.toml
+++ b/ssr-opengraph/wrangler.toml
@@ -1,0 +1,8 @@
+name = "ssr-opengraph"
+compatibility_date = "2023-01-01"
+
+routes = [
+  "kodadot.preschian.xyz/rmrk/gallery/*",
+  "kodadot.preschian.xyz/bsx/gallery/*",
+  "kodadot.preschian.xyz/snek/gallery/*",
+]

--- a/ssr-opengraph/wrangler.toml
+++ b/ssr-opengraph/wrangler.toml
@@ -2,7 +2,7 @@ name = "ssr-opengraph"
 compatibility_date = "2023-01-01"
 
 routes = [
-  "kodadot.preschian.xyz/rmrk/gallery/*",
-  "kodadot.preschian.xyz/bsx/gallery/*",
-  "kodadot.preschian.xyz/snek/gallery/*",
+  "kodadot.xyz/rmrk/gallery/*",
+  "kodadot.xyz/bsx/gallery/*",
+  "kodadot.xyz/snek/gallery/*",
 ]


### PR DESCRIPTION
related https://github.com/kodadot/nft-gallery/issues/5268

the method is quite similar
1. if the request is coming from a non-bot https://github.com/kodadot/workers/pull/41/files#diff-1860af2eaf6e2c14cc185436d808d762199ab1e9ec51fd94afe805d52bf8570eR18 it will continue the request
2. if the request is coming from a crawler (bot) it will fetch data to subsquid and then render static html https://github.com/kodadot/workers/pull/41/files#diff-1860af2eaf6e2c14cc185436d808d762199ab1e9ec51fd94afe805d52bf8570eR54

todo:
- [ ] collection detail
- [ ] rmrk2
- [ ] put `rmrk` to `@kodadot1/static`?

step to deploy:
1. after merging this PR, make sure to deploy the `prerender-opengraph` worker first
2. and then deploy `ssr-opengraph`. to avoid routes conflict https://github.com/kodadot/workers/pull/41/files#diff-50d1a6082b03f808cc776ab435488ebf63e81e82829e73e9fc76d094f2d5199aR4

additional notes:
- seems like prerender on netlify not working anymore. so, it will works on `kodadot.xyz` only