### PR TITLE
fix: canonical url and add error log

### DIFF
--- a/ssr-opengraph/src/index.tsx
+++ b/ssr-opengraph/src/index.tsx
@@ -7,6 +7,7 @@ import {
   getItemListByCollectionId,
   getNftById,
   getProperties,
+  jpegName,
 } from './utils';
 
 import type { Chains } from './utils';
@@ -43,7 +44,7 @@ app.get('/:chain/gallery/:id', async (c) => {
 
     // construct vercel image with cdn
     const image = new URL(
-      `https://og-image-green-seven.vercel.app/${name}.jpeg`
+      `https://og-image-green-seven.vercel.app/${jpegName(name)}`
     );
     image.searchParams.set('price', price);
     image.searchParams.set('image', cdn);
@@ -81,14 +82,14 @@ app.get('/:chain/collection/:id', async (c) => {
     ]);
     const { collection } = (collectionItem as CollectionEntity).data;
 
-    const canonical = `https://kodadot.xyz/${chain}/gallery/${id}`;
+    const canonical = `https://kodadot.xyz/${chain}/collection/${id}`;
     const { name, description, title, cdn } = await getProperties(collection);
 
     const price = (nfts as ListEntity).data.items.length || 0;
 
     // construct vercel image with cdn
     const image = new URL(
-      `https://og-image-green-seven.vercel.app/${name}.jpeg`
+      `https://og-image-green-seven.vercel.app/${jpegName(name)}`
     );
     image.searchParams.set('price', `Items: ${price}`);
     image.searchParams.set('image', cdn);
@@ -107,6 +108,11 @@ app.get('/:chain/collection/:id', async (c) => {
   }
 
   return fetch(c.req.url);
+});
+
+app.onError((err, c) => {
+  console.error(`${err}`);
+  return c.text(`path: ${c.req.url}`, 500);
 });
 
 export default app;

--- a/ssr-opengraph/src/template.tsx
+++ b/ssr-opengraph/src/template.tsx
@@ -41,5 +41,11 @@ export const Opengraph = (props: { siteData: SiteData; name: string }) => (
   <Layout {...props.siteData}>
     <h1>{props.siteData.title}</h1>
     <img src={props.siteData.image} alt={props.siteData.title} width="360" />
+    <p>
+      image url:{' '}
+      <a href={props.siteData.image} target="_blank">
+        {props.siteData.image}
+      </a>
+    </p>
   </Layout>
 );

--- a/ssr-opengraph/src/utils.ts
+++ b/ssr-opengraph/src/utils.ts
@@ -38,6 +38,11 @@ export function ipfsToCdn(ipfs: string) {
   return $purify(ipfs)[0];
 }
 
+export function jpegName(name: string) {
+  const lowerCase = encodeURIComponent(name.trim());
+  return `${lowerCase}.jpeg`;
+}
+
 export function formatPrice(price: string) {
   const number = BigInt(price);
   const format = formatBalance(number, {


### PR DESCRIPTION
not sure why I got different results between localhost and production. only in some items, overall seems ok

| localhost | production |
| --- | --- |
| ![Screenshot 2023-03-25 104123](https://user-images.githubusercontent.com/734428/227690226-e4a50f31-290b-4725-bd38-d0887e0aa539.png) | ![Screenshot 2023-03-25 104105](https://user-images.githubusercontent.com/734428/227690234-c3310152-4aae-492e-9327-96b6be2db5a9.png) |

broken url: 
- https://kodadot.xyz/rmrk/gallery/16818546-64F5867915CADA7250-UNSEEN-RETINA_REALM-0000000000000001
- https://www.opengraph.xyz/url/https%3A%2F%2Fkodadot.xyz%2Frmrk%2Fgallery%2F16818546-64F5867915CADA7250-UNSEEN-RETINA_REALM-0000000000000001

meanwhile, it works on my domain 🤔, hhmm:
- https://www.opengraph.xyz/url/https%3A%2F%2Fkodadot.preschian.xyz%2Frmrk%2Fgallery%2F16818546-64F5867915CADA7250-UNSEEN-RETINA_REALM-0000000000000001

changes:
- [x] fix canonical URL for collection detail
- [x] fix jpeg name
- [x] add error log