### PR TITLE
feat: resize image before uploading to cf-images

### DIFF
--- a/image-beta/src/utils/cloudflare-images.ts
+++ b/image-beta/src/utils/cloudflare-images.ts
@@ -11,11 +11,23 @@ export async function uploadToCloudflareImages({
   imageAccount: string;
   imageId: string;
 }) {
+  const imageOnIpfs = `${gateway}/ipfs/${path}`;
+
+  // resize image using wsrv.nl
+  const resizeImage = new URL('https://wsrv.nl');
+  resizeImage.searchParams.append('url', imageOnIpfs);
+  resizeImage.searchParams.append('w', '600');
+
+  console.log(resizeImage.toString());
+
+  await fetch(resizeImage.toString(), { method: 'HEAD' });
+
+  // upload image to cf-images
   const uploadHeaders = new Headers();
   uploadHeaders.append('Authorization', `Bearer ${token}`);
 
   const uploadFormData = new FormData();
-  uploadFormData.append('url', `${gateway}/ipfs/${path}`);
+  uploadFormData.append('url', resizeImage.toString());
   uploadFormData.append('id', path);
 
   const requestOptions = {

--- a/image-beta/src/utils/cloudflare-images.ts
+++ b/image-beta/src/utils/cloudflare-images.ts
@@ -16,7 +16,7 @@ export async function uploadToCloudflareImages({
   // resize image using wsrv.nl
   const resizeImage = new URL('https://wsrv.nl');
   resizeImage.searchParams.append('url', imageOnIpfs);
-  resizeImage.searchParams.append('w', '600');
+  resizeImage.searchParams.append('w', '1400');
 
   console.log(resizeImage.toString());
 


### PR DESCRIPTION
after researching with https://silvia-odwyer.github.io/photon/guide/, still unable to implement that on cf-workers

I found a simple alternative instead by using wsrv.nl. they are using Cloudflare and https://github.com/libvips/libvips. in this PR, we will resize all images to 600

| before | after |
| --- | --- |
| <img width="394" alt="Screenshot 2023-04-02 at 13 35 53" src="https://user-images.githubusercontent.com/734428/229336905-7513d589-96e6-49e3-9630-e6cfb5eb301f.png"> | <img width="389" alt="Screenshot 2023-04-02 at 13 36 58" src="https://user-images.githubusercontent.com/734428/229336912-2aebae20-7762-471f-81ba-d39a6c2b3d33.png"> |

related issue:
- https://github.com/kodadot/nft-gallery/issues/5202



Close kodadot/rubick#189