### PR TITLE
fix: check if name equal null

### DIFF
--- a/ssr-opengraph/src/utils.ts
+++ b/ssr-opengraph/src/utils.ts
@@ -65,7 +65,7 @@ function formatImage(url: string) {
 }
 
 export async function getProperties(nft: NFT) {
-  if (!nft?.meta) {
+  if (!nft?.meta || !nft?.name) {
     try {
       const response = await fetch(ipfsToCdn(nft?.metadata));
       const data = (await response.json()) as NFTMeta;

--- a/ssr-opengraph/src/utils.ts
+++ b/ssr-opengraph/src/utils.ts
@@ -78,11 +78,12 @@ export async function getProperties(nft: NFT) {
       };
     } catch (error) {
       console.log('Error on getProperties()', error);
+      const name = nft?.name || 'NFT Item';
 
       return {
-        name: nft?.name,
+        name: name,
         description: '',
-        title: `${nft?.name} | ${META_TITLE}`,
+        title: `${name} | ${META_TITLE}`,
         cdn: 'https://kodadot.xyz/k_card.png',
       };
     }


### PR DESCRIPTION
currently in some query there is possibility that nft?.name return null. this PR will check metadata in case nft?.name equal null