### PR TITLE
perf: improve seo scores

### DIFF
--- a/prerender/wrangler.toml
+++ b/prerender/wrangler.toml
@@ -17,4 +17,10 @@ routes = [
 	"kodadot.xyz/",
 	"kodadot.xyz/stmn/gallery/*",
 	"kodadot.xyz/stmn/collection/*",
+	"kodadot.xyz/ksm/create/",
+	"kodadot.xyz/ksm/explore/collectibles",
+	"kodadot.xyz/ksm/explore/items",
+	"kodadot.xyz/ksm/massmint",
+	"kodadot.xyz/series-insight/",
+	"kodadot.xyz/stmn/drops/free-drop",
 ]


### PR DESCRIPTION
- [x] Closes #115. improves seo scores from 55% to 80% by adding these routes and adding broken urls to prerender.io. (on this test, crawled 100 urls. meanwhile, on kodadot.xyz only 10 urls crawled. scores might be different)