### PR TITLE
Image Worker fails on CF Redirects

### DIFF
--- a/image/src/index.ts
+++ b/image/src/index.ts
@@ -73,7 +73,7 @@ app.all('/ipfs/*', async (c) => {
       }
 
       // fallback to cf-ipfs
-      return Response.redirect(`${c.env.CLOUDFLARE_GATEWAY}/ipfs/${path}`, 302);
+      return c.redirect(`${c.env.CLOUDFLARE_GATEWAY}/ipfs/${path}`, 302);
     }
 
     if (!response) {

--- a/image/src/index.ts
+++ b/image/src/index.ts
@@ -136,7 +136,7 @@ app.all('/ipfs/*', async (c) => {
       }
 
       // fallback to cf-ipfs
-      return Response.redirect(`${c.env.CLOUDFLARE_GATEWAY}/ipfs/${path}`, 302);
+      return c.redirect(`${c.env.CLOUDFLARE_GATEWAY}/ipfs/${path}`, 302);
     }
 
     const headers = new Headers();


### PR DESCRIPTION
The problem:

Looks like the gateway cannot correcly process redirects to CF gateways

- :bug: failed to fetch on KodaDot
- :bug: redirect fail on CF_Gateway

Now

![Screenshot 2023-07-31 at 14 00 50](https://github.com/kodadot/workers/assets/22471030/d6f60b47-3f17-4a50-b0c2-3c7130295dc2)

This PR

![Screenshot 2023-07-31 at 14 00 09](https://github.com/kodadot/workers/assets/22471030/64841735-4a66-41c6-8e80-1000974a6bb6)
