### PR TITLE
fix: dont return image on conflict status

### DIFF
--- a/image/src/utils/cloudflare-images.ts
+++ b/image/src/utils/cloudflare-images.ts
@@ -39,14 +39,14 @@ export async function uploadToCloudflareImages({
 
   const uploadCfImage = await fetch(
     `https://api.cloudflare.com/client/v4/accounts/${imageAccount}/images/v1`,
-    requestOptions
+    requestOptions,
   );
   const uploadStatus = uploadCfImage.status;
 
   console.log('uploadStatus', uploadStatus);
 
-  // if image supported by cf-images or already exists, redirect to cf-images
-  if (uploadStatus === 200 || uploadStatus === 409) {
+  // if image supported by cf-images, redirect to cf-images
+  if (uploadStatus === 200) {
     // return Response.redirect(`https://imagedelivery.net/${c.env.CF_IMAGE_ID}/${path}/public`, 302)
     return `https://imagedelivery.net/${imageId}/${path}/public`;
   }


### PR DESCRIPTION
Currently, the image worker returns 404 images to Cloudflare images. Because Cloudflare images return 409 status

https://canary.kodadot.xyz/ksm/gallery/13861243-3629a3ff458d113e25-WEAR-AGGRO_T_SHIRT-00000205

![image](https://github.com/kodadot/workers/assets/734428/10c3d37f-dec9-40c4-b849-55f0f240e662)
