### PR TITLE
feat: fetch ipfs synchronously

### DIFF
--- a/image/src/utils/ipfs.ts
+++ b/image/src/utils/ipfs.ts
@@ -1,0 +1,57 @@
+type FetchIPFS = {
+  path: string;
+  gateway1: string;
+  gateway2: string;
+};
+
+export async function fetchIPFS({ path, gateway1, gateway2 }: FetchIPFS) {
+  const gwNftstorage = await fetch(`https://nftstorage.link/ipfs/${path}`);
+  console.log('fetch IPFS status', 'nftstorage.link', gwNftstorage.status);
+
+  if (gwNftstorage.status === 200) {
+    return {
+      headers: gwNftstorage.headers,
+      body: gwNftstorage.body,
+      ok: true,
+    };
+  }
+
+  const gwCfIpfs = await fetch(`https://cloudflare-ipfs.com/ipfs/${path}`);
+  console.log('fetch IPFS status', 'cloudflare-ipfs.com', gwCfIpfs.status);
+
+  if (gwCfIpfs.status === 200) {
+    return {
+      headers: gwCfIpfs.headers,
+      body: gwCfIpfs.body,
+      ok: true,
+    };
+  }
+
+  const gw1 = await fetch(`${gateway1}/ipfs/${path}`);
+  console.log('fetch IPFS status', gateway1, gw1.status);
+
+  if (gw1.status === 200) {
+    return {
+      headers: gw1.headers,
+      body: gw1.body,
+      ok: true,
+    };
+  }
+
+  const gw2 = await fetch(`${gateway2}/ipfs/${path}`);
+  console.log('fetch IPFS status', gateway2, gw2.status);
+
+  if (gw2.status === 200) {
+    return {
+      headers: gw2.headers,
+      body: gw2.body,
+      ok: true,
+    };
+  }
+
+  return {
+    headers: null,
+    body: null,
+    ok: false,
+  };
+}


### PR DESCRIPTION
While testing this PR https://github.com/kodadot/workers/pull/136, I found that some ipfs cid somehow request to filebase persistent returned 403. it will persistent to redirect it to cf-ipfs

![Screenshot 2023-08-18 124107](https://user-images.githubusercontent.com/734428/261558301-3461d301-067a-4f92-bd72-44d8dfebb8bb.png)

What if we synchronously fetch ipfs?

pros:
- fewer requests to our gateway (reduce cost)
- more precise

cons:
- little bit of increased response time