### PR TITLE
fix: remove nftstorage because of invalid of content-type

### DIFF
--- a/image/src/utils/ipfs.ts
+++ b/image/src/utils/ipfs.ts
@@ -5,17 +5,6 @@ type FetchIPFS = {
 };
 
 export async function fetchIPFS({ path, gateway1, gateway2 }: FetchIPFS) {
-  const gwNftstorage = await fetch(`https://nftstorage.link/ipfs/${path}`);
-  console.log('fetch IPFS status', 'nftstorage.link', gwNftstorage.status);
-
-  if (gwNftstorage.status === 200) {
-    return {
-      headers: gwNftstorage.headers,
-      body: gwNftstorage.body,
-      ok: true,
-    };
-  }
-
   const gwCfIpfs = await fetch(`https://cloudflare-ipfs.com/ipfs/${path}`);
   console.log('fetch IPFS status', 'cloudflare-ipfs.com', gwCfIpfs.status);
 


### PR DESCRIPTION
- [x] Closes https://github.com/kodadot/workers/issues/145

content-type from nftstorage is invalid

![Screenshot 2023-09-04 141457](https://github.com/kodadot/workers/assets/734428/45ed650d-8c55-41e8-a4ec-eb21ff65b1d9)

this is on cloudflare-ipfs

![Screenshot 2023-09-04 141655](https://github.com/kodadot/workers/assets/734428/edb89838-7f7e-472f-96c9-5ef7156a4ac4)

this is on filebase

![image](https://github.com/kodadot/workers/assets/734428/6ea3adc4-03d9-422e-a4c0-d2279e10c9d9)

this is on infura

![image](https://github.com/kodadot/workers/assets/734428/e6f03dde-9233-43cc-bbba-b55ba03fd10a)




let's drop nftstorage on image-workers