### PR TITLE
fix: redirect status code 301

### DIFF
--- a/image/src/index.ts
+++ b/image/src/index.ts
@@ -79,7 +79,7 @@ app.all('/ipfs/*', async (c) => {
         });
 
         if (imageUrl && !isOriginal) {
-          return c.redirect(imageUrl, 302);
+          return c.redirect(imageUrl, 301);
         }
 
         // else, render r2 object
@@ -105,7 +105,7 @@ app.all('/ipfs/*', async (c) => {
       }
 
       // fallback to cf-ipfs
-      return c.redirect(`${c.env.CLOUDFLARE_GATEWAY}/ipfs/${path}`, 302);
+      return c.redirect(`${c.env.CLOUDFLARE_GATEWAY}/ipfs/${path}`, 301);
     }
 
     if (!response) {
@@ -118,7 +118,7 @@ app.all('/ipfs/*', async (c) => {
 
         // return early to cf-images
         if (currentImage.ok) {
-          return c.redirect(cfImage, 302);
+          return c.redirect(cfImage, 301);
         }
 
         // else, upload to cf-images
@@ -132,7 +132,7 @@ app.all('/ipfs/*', async (c) => {
         // redirect to cf-images
         if (imageUrl) {
           // how to cache redirect response?
-          return c.redirect(imageUrl, 302);
+          return c.redirect(imageUrl, 301);
         }
       }
 
@@ -148,10 +148,7 @@ app.all('/ipfs/*', async (c) => {
       });
 
       response.headers.append('cache-control', `s-maxage=${CACHE_DAY}`);
-      response.headers.append(
-        'content-range',
-        `bytes 0-${object.size - 1}/${object.size}`,
-      );
+      response.headers.append('content-range', `bytes 0-${object.size - 1}/${object.size}`);
 
       // TODO: TypeError: Can't modify immutable headers.
       // c.executionCtx.waitUntil(cache.put(cacheKey, response.clone()));
@@ -179,7 +176,7 @@ app.all('/ipfs/*', async (c) => {
       }
 
       // fallback to cf-ipfs
-      return c.redirect(`${c.env.CLOUDFLARE_GATEWAY}/ipfs/${path}`, 302);
+      return c.redirect(`${c.env.CLOUDFLARE_GATEWAY}/ipfs/${path}`, 301);
     }
 
     const headers = new Headers();


### PR DESCRIPTION
I just noticed that on Chrome, some of the requests were stalled until `12s`. It works fine and loads faster on Firefox.

![image](https://github.com/kodadot/workers/assets/734428/58ba4eb7-672a-4ed1-885f-b6a0b5a0142d)


Hi @kodadot/internal-dev, I am currently deploying this PR to canary/beta env to test the issue. Please report here if you find an error regarding the 301 status code requests to the image worker.