### PR TITLE
Capture worker v1

### DIFF
--- a/capture/.vscode/settings.json
+++ b/capture/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "deno.enable": false,
+}

--- a/capture/package-lock.json
+++ b/capture/package-lock.json
@@ -8,11 +8,13 @@
             "name": "screenshot",
             "version": "0.0.0",
             "dependencies": {
-                "hono": "^3.9.0"
+                "hono": "^3.9.0",
+                "ufo": "^1.3.2"
             },
             "devDependencies": {
                 "@cloudflare/puppeteer": "^0.0.5",
                 "@cloudflare/workers-types": "^4.20230419.0",
+                "prettier": "^3.1.0",
                 "typescript": "^5.0.4",
                 "wrangler": "^3.0.0"
             }
@@ -1192,6 +1194,21 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/prettier": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+            "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
         "node_modules/printable-characters": {
             "version": "1.0.42",
             "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
@@ -1378,6 +1395,11 @@
             "engines": {
                 "node": ">=14.17"
             }
+        },
+        "node_modules/ufo": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
+            "integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA=="
         },
         "node_modules/undici": {
             "version": "5.27.0",

--- a/capture/package.json
+++ b/capture/package.json
@@ -3,18 +3,20 @@
     "version": "0.0.0",
     "private": true,
     "scripts": {
-      "deploy": "wrangler deploy",
-      "dev": "wrangler dev",
-      "start": "wrangler dev"
+        "deploy": "wrangler deploy",
+        "dev": "wrangler dev",
+        "start": "wrangler dev",
+				"fmt": "prettier --write ./src"
     },
-		"dependencies": {
-      "hono": "^3.9.0"
+    "dependencies": {
+        "hono": "^3.9.0",
+        "ufo": "^1.3.2"
     },
     "devDependencies": {
-      "@cloudflare/workers-types": "^4.20230419.0",
-      "typescript": "^5.0.4",
-      "wrangler": "^3.0.0",
-      "@cloudflare/puppeteer": "^0.0.5"
+        "@cloudflare/puppeteer": "^0.0.5",
+        "@cloudflare/workers-types": "^4.20230419.0",
+        "prettier": "^3.1.0",
+        "typescript": "^5.0.4",
+        "wrangler": "^3.0.0"
     }
-  }
-
+}

--- a/capture/src/index.ts
+++ b/capture/src/index.ts
@@ -12,6 +12,21 @@ type ScreenshotRequest = {
 }
 
 app.get('/', (c) => c.text('KODADOT CAPTURE SERVICE - https://kodadot.xyz'));
+
+app.use('/batch', cors({ origin: allowedOrigin }));
+
+
+app.post('/batch', async (c) => {
+	const id = c.env.BROWSER.idFromName("browser");
+	const obj = c.env.BROWSER.get(id);
+
+	// Send a request to the Durable Object, then await its response.
+	const resp = await obj.fetch(c.req.url)
+
+	return resp;
+});
+
+
 app.use('/screenshot', cors({ origin: allowedOrigin }));
 
 app.post('/screenshot', async (c) => {

--- a/capture/src/index.ts
+++ b/capture/src/index.ts
@@ -5,6 +5,8 @@ import { cors } from 'hono/cors';
 
 import { allowedOrigin } from './utils/cors';
 
+export { Browser } from './object';
+
 const app = new Hono<{ Bindings: Env }>();
 
 type ScreenshotRequest = {
@@ -18,12 +20,22 @@ app.use('/batch', cors({ origin: allowedOrigin }));
 
 app.post('/batch', async (c) => {
 	const id = c.env.BROWSER.idFromName("browser");
+
+	console.log('id',id);
+
 	const obj = c.env.BROWSER.get(id);
 
-	// Send a request to the Durable Object, then await its response.
-	const resp = await obj.fetch(c.req.url)
+	console.log('obj',obj);
 
-	return resp;
+	console.log('c.req.url',c.req.url);
+	// Send a request to the Durable Object, then await its response.
+	const resp = await obj.fetch(c.req.url, { body: JSON.stringify(await c.req.json()), method: 'POST' } )
+
+	if (resp.status !== 200) {
+		return c.json({ error: 'element not found' }, 400);
+	}
+
+	return c.json(await resp.json(), 200);
 });
 
 
@@ -78,3 +90,5 @@ app.post('/screenshot', async (c) => {
 });
 
 export default app;
+
+

--- a/capture/src/object.ts
+++ b/capture/src/object.ts
@@ -3,8 +3,8 @@ import { Env } from './utils/constants';
 import { $URL, parseURL, withTrailingSlash } from 'ufo';
 
 const KEEP_BROWSER_ALIVE_IN_SECONDS = 60;
-const DEFAULT_VIEWPORT_WIDTH = 800;
-const DEFAULT_VIEWPORT_HEIGHT = 800;
+const DEFAULT_VIEWPORT_WIDTH = 600;
+const DEFAULT_VIEWPORT_HEIGHT = 600;
 const PAGE_TIMEOUT = 300000;
 
 const viewportSettings = {
@@ -55,8 +55,6 @@ export class Browser {
 
 		// Reset keptAlive after each call to the DO
 		this.keptAliveInSeconds = 0;
-
-		console.log(`Browser DO: Fetching ${this.browser}`);
 
 		if (!this.browser) {
 			return new Response('Browser DO: Could not start browser instance.', { status: 499 });

--- a/capture/src/object.ts
+++ b/capture/src/object.ts
@@ -42,39 +42,6 @@ export class Browser {
 		}
 	}
 
-	// private async makeScreenshots(possiblyUrls: string[]) {
-	// 	const page = await this.browser!.newPage();
-
-	// 	// const body = await request.json() as ScreenshotRequest;
-
-	// 	const urls = possiblyUrls.filter(Boolean);
-
-	// 	for (const url of urls) {
-	// 		await page.setViewport(viewportSettings);
-	// 		await page.goto(url);
-
-	// 		const selector = 'canvas';
-	// 		await page.waitForSelector(selector);
-
-	// 		const element = await page.$(selector);
-
-	// 		if (!element) {
-	// 			console.log(`Browser: element not found`);
-	// 			continue
-	// 		}
-
-	// 		const normalizedUrl = new URL(url);
-
-	// 		const fileName = normalizedUrl.pathname.replace(/\//g, '_') + '_' + normalizedUrl.searchParams.get('hash');
-	// 		const sc = await page.screenshot({
-	// 			path: fileName + '.jpeg',
-	// 		});
-
-	// 		await this.env.BUCKET.put(fileName + '.jpeg', sc);
-	// 	}
-	// }
-
-
 
 	async fetch(request: Request) {
 		await this.initBrowser();

--- a/capture/src/object.ts
+++ b/capture/src/object.ts
@@ -1,0 +1,152 @@
+import puppeteer, { type Browser as PuppeteerBrowser } from '@cloudflare/puppeteer';
+import { Env } from './utils/constants';
+
+const KEEP_BROWSER_ALIVE_IN_SECONDS = 60;
+const DEFAULT_VIEWPORT_WIDTH = 800
+const DEFAULT_VIEWPORT_HEIGHT = 800
+const PAGE_TIMEOUT = 300000
+
+const viewportSettings = {
+	deviceScaleFactor: 1,
+	width: DEFAULT_VIEWPORT_WIDTH,
+	height: DEFAULT_VIEWPORT_HEIGHT,
+}
+
+type ScreenshotRequest = {
+	urls: string[]
+}
+
+export class Browser {
+	state: DurableObjectState;
+	env: Env;
+	keptAliveInSeconds: number;
+	storage: DurableObjectStorage;
+	browser?: PuppeteerBrowser;
+
+	constructor(state: DurableObjectState, env: Env) {
+		this.state = state;
+		this.env = env;
+		this.keptAliveInSeconds = 0;
+		this.storage = this.state.storage;
+	}
+
+
+	private async initBrowser() {
+		if (!this.browser || !this.browser.isConnected()) {
+			console.log(`Browser DO: Starting new instance`);
+			try {
+				this.browser = await puppeteer.launch(this.env.BW);
+			} catch (e) {
+				console.log(`Browser DO: Could not start browser instance. Error: ${e}`);
+			}
+		}
+	}
+
+	// private async makeScreenshots(possiblyUrls: string[]) {
+	// 	const page = await this.browser!.newPage();
+
+	// 	// const body = await request.json() as ScreenshotRequest;
+
+	// 	const urls = possiblyUrls.filter(Boolean);
+
+	// 	for (const url of urls) {
+	// 		await page.setViewport(viewportSettings);
+	// 		await page.goto(url);
+
+	// 		const selector = 'canvas';
+	// 		await page.waitForSelector(selector);
+
+	// 		const element = await page.$(selector);
+
+	// 		if (!element) {
+	// 			console.log(`Browser: element not found`);
+	// 			continue
+	// 		}
+
+	// 		const normalizedUrl = new URL(url);
+
+	// 		const fileName = normalizedUrl.pathname.replace(/\//g, '_') + '_' + normalizedUrl.searchParams.get('hash');
+	// 		const sc = await page.screenshot({
+	// 			path: fileName + '.jpeg',
+	// 		});
+
+	// 		await this.env.BUCKET.put(fileName + '.jpeg', sc);
+	// 	}
+	// }
+
+
+
+	async fetch(request: Request) {
+		await this.initBrowser();
+
+		// Reset keptAlive after each call to the DO
+		this.keptAliveInSeconds = 0;
+
+		if (!this.browser) {
+			return new Response('error');
+		}
+
+		const page = await this.browser.newPage();
+
+		const body = await request.json() as ScreenshotRequest;
+
+		const urls = body.urls.filter(Boolean);
+
+		const captures = [];
+
+		for (const url of urls) {
+			await page.setViewport(viewportSettings);
+			await page.goto(url);
+
+			const selector = 'canvas';
+			await page.waitForSelector(selector);
+
+			const element = await page.$(selector);
+
+			if (!element) {
+				console.log(`Browser: element not found`);
+				continue
+			}
+
+			const normalizedUrl = new URL(url);
+
+			const fileName = normalizedUrl.pathname.replace(/\//g, '_') + '_' + normalizedUrl.searchParams.get('hash');
+
+
+			const sc = await element.screenshot();
+
+			await this.env.BUCKET.put(fileName + '.jpeg', sc);
+			captures.push(this.env.PUBLIC_URL + '/' + fileName + '.jpeg');
+
+		}
+
+		// Reset keptAlive after performing tasks to the DO.
+		this.keptAliveInSeconds = 0;
+
+		// set the first alarm to keep DO alive
+		let currentAlarm = await this.storage.getAlarm();
+		if (currentAlarm == null) {
+			console.log(`Browser DO: setting alarm`);
+			const TEN_SECONDS = 10 * 1000;
+			await this.storage.setAlarm(Date.now() + TEN_SECONDS);
+		}
+
+		return new Response(JSON.stringify({ captures }));
+	}
+
+	async alarm() {
+		this.keptAliveInSeconds += 10;
+
+		// Extend browser DO life
+		if (this.keptAliveInSeconds < KEEP_BROWSER_ALIVE_IN_SECONDS) {
+			console.log(`Browser DO: has been kept alive for ${this.keptAliveInSeconds} seconds. Extending lifespan.`);
+			await this.storage.setAlarm(Date.now() + 10 * 1000);
+		} else {
+			console.log(`Browser DO: exceeded life of ${KEEP_BROWSER_ALIVE_IN_SECONDS}s.`);
+			if (this.browser) {
+				console.log(`Closing browser.`);
+				await this.browser.close();
+			}
+		}
+	}
+}

--- a/capture/src/object.ts
+++ b/capture/src/object.ts
@@ -42,6 +42,8 @@ export class Browser {
 		}
 	}
 
+
+
 	async fetch(request: Request) {
 		// return new Response("success");
 		const body = (await request.json()) as ScreenshotRequest;
@@ -87,7 +89,7 @@ export class Browser {
 			const sc = await element.screenshot();
 
 			await this.env.BUCKET.put(fileName, sc);
-			captures.push(this.env.PUBLIC_URL + '/' + fileName);
+			captures.push(fileName);
 		}
 
 		// Reset keptAlive after performing tasks to the DO.

--- a/capture/src/object.ts
+++ b/capture/src/object.ts
@@ -44,20 +44,26 @@ export class Browser {
 
 
 	async fetch(request: Request) {
+		// return new Response("success");
+		const body = await request.json() as ScreenshotRequest;
+		const urls = body.urls.filter(Boolean);
+
+		console.log(`Browser DO: Fetching ${urls.length} urls`);
+
 		await this.initBrowser();
 
 		// Reset keptAlive after each call to the DO
 		this.keptAliveInSeconds = 0;
 
+		console.log(`Browser DO: Fetching ${this.browser}`);
+
+
 		if (!this.browser) {
-			return new Response('error');
+			return new Response('Browser DO: Could not start browser instance.', { status: 499 });
 		}
 
 		const page = await this.browser.newPage();
 
-		const body = await request.json() as ScreenshotRequest;
-
-		const urls = body.urls.filter(Boolean);
 
 		const captures = [];
 

--- a/capture/src/utils/constants.ts
+++ b/capture/src/utils/constants.ts
@@ -1,11 +1,9 @@
 export type Env = {
 	BW: Fetcher;
 	BUCKET: R2Bucket;
-	BROWSER: DurableObjectNamespace
+	BROWSER: DurableObjectNamespace;
 	PUBLIC_URL: string;
 	// BROWSER_CACHE: KVNamespace;
-
 };
-
 
 export const ORIGIN = 'https://kodadot.xyz';

--- a/capture/src/utils/constants.ts
+++ b/capture/src/utils/constants.ts
@@ -1,6 +1,9 @@
 export type Env = {
 	BW: Fetcher;
-	// BROWSER_KV_DEMO: KVNamespace;
+	BUCKET: R2Bucket;
+	BROWSER: DurableObjectNamespace
+	PUBLIC_URL: string;
+	// BROWSER_CACHE: KVNamespace;
 
 };
 

--- a/capture/src/utils/cors.ts
+++ b/capture/src/utils/cors.ts
@@ -1,16 +1,16 @@
 import { ORIGIN } from './constants';
 
 const MATCHES: RegExp[] = [
-  /deploy-preview-[0-9]+--koda-canary.netlify.app/,
-  /deploy-preview-[0-9]+--nuxt-kodadot.netlify.app/,
-  /kodadot.xyz/,
-  /localhost:9090/,
+	/deploy-preview-[0-9]+--koda-canary.netlify.app/,
+	/deploy-preview-[0-9]+--nuxt-kodadot.netlify.app/,
+	/kodadot.xyz/,
+	/localhost:9090/,
 ];
 
 export const allowedOrigin = (origin: string): string | undefined | null => {
-  const match = MATCHES.find((r) => r.test(origin));
-  if (match) {
-    return origin;
-  }
-  return ORIGIN;
+	const match = MATCHES.find((r) => r.test(origin));
+	if (match) {
+		return origin;
+	}
+	return ORIGIN;
 };

--- a/capture/src/utils/shared.ts
+++ b/capture/src/utils/shared.ts
@@ -1,0 +1,10 @@
+import { $URL, withTrailingSlash } from 'ufo'
+
+export function urlToFileName(url: string): string {
+	const normalizedUrl = new $URL(url);
+
+	const path = withTrailingSlash(normalizedUrl.pathname.replace('/ipfs/', ''));
+
+	const fileName = path + normalizedUrl.query.hash + '.png';
+	return fileName;
+}

--- a/capture/wrangler.toml
+++ b/capture/wrangler.toml
@@ -14,11 +14,13 @@ PUBLIC_URL = "https://pub-9eb6a8bdc529419785a85d0e2f46c46a.r2.dev"
 [[r2_buckets]]
 binding = "BUCKET"
 bucket_name = "screenshots"
+preview_bucket_name="fake-screenshots"
 
 # Binding to a Durable Object
 [[durable_objects.bindings]]
 name = "BROWSER"
 class_name = "Browser"
+
 
 [env.beta]
 name = 'capture-beta'
@@ -34,6 +36,7 @@ PUBLIC_URL = "https://pub-9eb6a8bdc529419785a85d0e2f46c46a.r2.dev"
 [[env.beta.r2_buckets]]
 binding = "BUCKET"
 bucket_name = "screenshots"
+preview_bucket_name="fake-screenshots"
 
 # Binding to a Durable Object
 [[env.beta.durable_objects.bindings]]

--- a/capture/wrangler.toml
+++ b/capture/wrangler.toml
@@ -22,6 +22,11 @@ class_name = "Browser"
 
 [env.beta]
 name = 'capture-beta'
+browser = { binding = "BW" }
+
+[[migrations]]
+tag = "v1" # Should be unique for each entry
+new_classes = ["Browser"]
 
 [env.beta.vars]
 PUBLIC_URL = "https://pub-9eb6a8bdc529419785a85d0e2f46c46a.r2.dev"
@@ -34,4 +39,8 @@ bucket_name = "screenshots"
 [[env.beta.durable_objects.bindings]]
 name = "BROWSER"
 class_name = "Browser"
+
+[[env.beta.migrations]]
+tag = "v1" # Should be unique for each entry
+new_classes = ["Browser"]
 

--- a/capture/wrangler.toml
+++ b/capture/wrangler.toml
@@ -7,6 +7,11 @@ browser = { binding = "BW" }
 # kv_namespaces = [
 #   { binding = "BROWSER_KV_DEMO", id = "f4a99377d30a45f395718628a00c0cf9", preview_id = "24fef87419a14b339c6440310a0cc1a2" }
 # ]
+[vars]
+PUBLIC_URL = "https://pub-9eb6a8bdc529419785a85d0e2f46c46a.r2.dev"
+
+[env.beta]
+name = 'capture-beta'
 
 # Bind an R2 Bucket
 [[r2_buckets]]

--- a/capture/wrangler.toml
+++ b/capture/wrangler.toml
@@ -44,6 +44,6 @@ name = "BROWSER"
 class_name = "Browser"
 
 [[env.beta.migrations]]
-tag = "v1" # Should be unique for each entry
+tag = "v2" # Should be unique for each entry
 new_classes = ["Browser"]
 

--- a/capture/wrangler.toml
+++ b/capture/wrangler.toml
@@ -10,9 +10,6 @@ browser = { binding = "BW" }
 [vars]
 PUBLIC_URL = "https://pub-9eb6a8bdc529419785a85d0e2f46c46a.r2.dev"
 
-[env.beta]
-name = 'capture-beta'
-
 # Bind an R2 Bucket
 [[r2_buckets]]
 binding = "BUCKET"
@@ -20,6 +17,21 @@ bucket_name = "screenshots"
 
 # Binding to a Durable Object
 [[durable_objects.bindings]]
+name = "BROWSER"
+class_name = "Browser"
+
+[env.beta]
+name = 'capture-beta'
+
+[env.beta.vars]
+PUBLIC_URL = "https://pub-9eb6a8bdc529419785a85d0e2f46c46a.r2.dev"
+
+[[env.beta.r2_buckets]]
+binding = "BUCKET"
+bucket_name = "screenshots"
+
+# Binding to a Durable Object
+[[env.beta.durable_objects.bindings]]
 name = "BROWSER"
 class_name = "Browser"
 

--- a/capture/wrangler.toml
+++ b/capture/wrangler.toml
@@ -7,3 +7,14 @@ browser = { binding = "BW" }
 # kv_namespaces = [
 #   { binding = "BROWSER_KV_DEMO", id = "f4a99377d30a45f395718628a00c0cf9", preview_id = "24fef87419a14b339c6440310a0cc1a2" }
 # ]
+
+# Bind an R2 Bucket
+[[r2_buckets]]
+binding = "BUCKET"
+bucket_name = "screenshots"
+
+# Binding to a Durable Object
+[[durable_objects.bindings]]
+name = "BROWSER"
+class_name = "Browser"
+


### PR DESCRIPTION
https://developers.cloudflare.com/browser-rendering/get-started/browser-rendering-with-do/

This will prolong lifespan of Browser up to One minute + can do response in batches

- :adding: things
- :wrench: vars + DO
- :zap: new features from CF <3
- :sparkles: batch dont fail

## Context

- Thanks to the durable object the browser will live min one min if unused -> many users can share session - fast and effective for making screenshots.
- `/screenshot` has still the same api
- `/batch` to capture multiple - returns links to R2

## Testing

From bottom to top

### `Older than week` 

That is the old capture v0

### `Less than two hours ago`

This but only on new content

### `TOP`

This, but content is in R2. 


<img width="579" alt="Screenshot 2023-11-27 at 19 34 01" src="https://github.com/kodadot/workers/assets/22471030/a99deb6a-fb76-403a-b536-552b392727ba">


### Things for v2

1:1 to fx-capture
optimize fetching, times on DO <-> R2 <-> others