### PR TITLE
fixed issue nft-gallery:10004

### DIFF
--- a/image/src/routes/metadata.ts
+++ b/image/src/routes/metadata.ts
@@ -15,21 +15,7 @@ const toExternalGateway = (url: string) => {
   return url.includes(KODA_WORKERS) ? toIPFSDedicated(url) : url
 }
 
-const getMimeType = async (url: string): Promise<string> => {
-  if (!url) {
-    return ''
-  }
 
-  const externalUrl = toExternalGateway(url)
-  const data = await fetch(externalUrl, { method: 'HEAD' })
-  const contentType = data.headers.get('content-type')
-
-  if (data.status !== 200) {
-    return await getMimeType(url)
-  }
-
-  return contentType ?? ''
-}
 
 app.use('/*', cors({ origin: allowedOrigin }))
 
@@ -62,6 +48,7 @@ app.get('/*', async (c) => {
     // @ts-ignore
     const normalized = normalize(content, ipfsUrl)
 
+    const getMimeType = await import('../utils/get-mime-type').then((module) => module.getMimeType)
     const imageMimeType = await getMimeType(normalized.image)
     const animationUrlMimeType = await getMimeType(normalized.animationUrl)
 

--- a/image/src/utils/get-mime-type.ts
+++ b/image/src/utils/get-mime-type.ts
@@ -1,0 +1,23 @@
+import {  toIPFSDedicated } from '../utils/ipfs'
+
+const toExternalGateway = (url: string) => {
+    const KODA_WORKERS = 'w.kodadot.xyz/ipfs/'
+  
+    return url.includes(KODA_WORKERS) ? toIPFSDedicated(url) : url
+  }
+
+export const getMimeType = async (url: string , routeType: 'metadata' | 'typeEndpoint' = 'metadata'): Promise<string> => {
+    if (!url) {
+      return ''
+    }
+  
+    const externalUrl = ( routeType == 'metadata' ) ?  toExternalGateway(url) : url
+    const data = await fetch(externalUrl, { method: 'HEAD' })
+    const contentType = data.headers.get('content-type')
+  
+    if (data.status !== 200) {
+      return await getMimeType(url , routeType)
+    }
+  
+    return contentType ?? ''
+  }


### PR DESCRIPTION
As described here: [https://github.com/kodadot/nft-gallery/issues/10004#issuecomment-2041567279](nft-gallery:10004) the issue #10004 on nft-gallery was happening due lack of mimeType property in the final response when request made to `GET /type/endpoint  ` endpoint. i implemented a fix by getting actual image path from ipfs and getting mime-type of the image file. then i assign it to the final response and convert it to the readableStream before sending to the client