### PR TITLE
fix: remove ipfs-path cache

### DIFF
--- a/image/package-lock.json
+++ b/image/package-lock.json
@@ -149,9 +149,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.10.tgz",
-      "integrity": "sha512-Q+mk96KJ+FZ30h9fsJl+67IjNJm3x2eX+GBWGmocAKgzp27cowCOOqSdscX80s0SpdFXZnIv/+1xD1EctFx96Q==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
       "cpu": [
         "ppc64"
       ],
@@ -165,9 +165,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.10.tgz",
-      "integrity": "sha512-7W0bK7qfkw1fc2viBfrtAEkDKHatYfHzr/jKAHNr9BvkYDXPcC6bodtm8AyLJNNuqClLNaeTLuwURt4PRT9d7w==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
       "cpu": [
         "arm"
       ],
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.10.tgz",
-      "integrity": "sha512-1X4CClKhDgC3by7k8aOWZeBXQX8dHT5QAMCAQDArCLaYfkppoARvh0fit3X2Qs+MXDngKcHv6XXyQCpY0hkK1Q==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
       "cpu": [
         "arm64"
       ],
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.10.tgz",
-      "integrity": "sha512-O/nO/g+/7NlitUxETkUv/IvADKuZXyH4BHf/g/7laqKC4i/7whLpB0gvpPc2zpF0q9Q6FXS3TS75QHac9MvVWw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
       "cpu": [
         "x64"
       ],
@@ -229,9 +229,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.10.tgz",
-      "integrity": "sha512-alfGtT+IEICKtNE54hbvPg13xGBe4GkVxyGWtzr+yHO7HIiRJppPDhOKq3zstTcVf8msXb/t4eavW3jCDpMSmA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
       "cpu": [
         "x64"
       ],
@@ -245,9 +245,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.10.tgz",
-      "integrity": "sha512-dMtk1wc7FSH8CCkE854GyGuNKCewlh+7heYP/sclpOG6Cectzk14qdUIY5CrKDbkA/OczXq9WesqnPl09mj5dg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
       "cpu": [
         "arm64"
       ],
@@ -261,9 +261,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.10.tgz",
-      "integrity": "sha512-G5UPPspryHu1T3uX8WiOEUa6q6OlQh6gNl4CO4Iw5PS+Kg5bVggVFehzXBJY6X6RSOMS8iXDv2330VzaObm4Ag==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
       "cpu": [
         "x64"
       ],
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.10.tgz",
-      "integrity": "sha512-j6gUW5aAaPgD416Hk9FHxn27On28H4eVI9rJ4az7oCGTFW48+LcgNDBN+9f8rKZz7EEowo889CPKyeaD0iw9Kg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
       "cpu": [
         "arm"
       ],
@@ -293,9 +293,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.10.tgz",
-      "integrity": "sha512-QxaouHWZ+2KWEj7cGJmvTIHVALfhpGxo3WLmlYfJ+dA5fJB6lDEIg+oe/0//FuyVHuS3l79/wyBxbHr0NgtxJQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
       "cpu": [
         "arm64"
       ],
@@ -309,9 +309,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.10.tgz",
-      "integrity": "sha512-4ub1YwXxYjj9h1UIZs2hYbnTZBtenPw5NfXCRgEkGb0b6OJ2gpkMvDqRDYIDRjRdWSe/TBiZltm3Y3Q8SN1xNg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
       "cpu": [
         "ia32"
       ],
@@ -325,9 +325,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.10.tgz",
-      "integrity": "sha512-lo3I9k+mbEKoxtoIbM0yC/MZ1i2wM0cIeOejlVdZ3D86LAcFXFRdeuZmh91QJvUTW51bOK5W2BznGNIl4+mDaA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
       "cpu": [
         "loong64"
       ],
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.10.tgz",
-      "integrity": "sha512-J4gH3zhHNbdZN0Bcr1QUGVNkHTdpijgx5VMxeetSk6ntdt+vR1DqGmHxQYHRmNb77tP6GVvD+K0NyO4xjd7y4A==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
       "cpu": [
         "mips64el"
       ],
@@ -357,9 +357,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.10.tgz",
-      "integrity": "sha512-tgT/7u+QhV6ge8wFMzaklOY7KqiyitgT1AUHMApau32ZlvTB/+efeCtMk4eXS+uEymYK249JsoiklZN64xt6oQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
       "cpu": [
         "ppc64"
       ],
@@ -373,9 +373,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.10.tgz",
-      "integrity": "sha512-0f/spw0PfBMZBNqtKe5FLzBDGo0SKZKvMl5PHYQr3+eiSscfJ96XEknCe+JoOayybWUFQbcJTrk946i3j9uYZA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
       "cpu": [
         "riscv64"
       ],
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.10.tgz",
-      "integrity": "sha512-pZFe0OeskMHzHa9U38g+z8Yx5FNCLFtUnJtQMpwhS+r4S566aK2ci3t4NCP4tjt6d5j5uo4h7tExZMjeKoehAA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
       "cpu": [
         "s390x"
       ],
@@ -405,9 +405,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.10.tgz",
-      "integrity": "sha512-SpYNEqg/6pZYoc+1zLCjVOYvxfZVZj6w0KROZ3Fje/QrM3nfvT2llI+wmKSrWuX6wmZeTapbarvuNNK/qepSgA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
       "cpu": [
         "x64"
       ],
@@ -421,9 +421,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.10.tgz",
-      "integrity": "sha512-ACbZ0vXy9zksNArWlk2c38NdKg25+L9pr/mVaj9SUq6lHZu/35nx2xnQVRGLrC1KKQqJKRIB0q8GspiHI3J80Q==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
       "cpu": [
         "x64"
       ],
@@ -437,9 +437,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.10.tgz",
-      "integrity": "sha512-PxcgvjdSjtgPMiPQrM3pwSaG4kGphP+bLSb+cihuP0LYdZv1epbAIecHVl5sD3npkfYBZ0ZnOjR878I7MdJDFg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
       "cpu": [
         "x64"
       ],
@@ -453,9 +453,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.10.tgz",
-      "integrity": "sha512-ZkIOtrRL8SEJjr+VHjmW0znkPs+oJXhlJbNwfI37rvgeMtk3sxOQevXPXjmAPZPigVTncvFqLMd+uV0IBSEzqA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
       "cpu": [
         "x64"
       ],
@@ -469,9 +469,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.10.tgz",
-      "integrity": "sha512-+Sa4oTDbpBfGpl3Hn3XiUe4f8TU2JF7aX8cOfqFYMMjXp6ma6NJDztl5FDG8Ezx0OjwGikIHw+iA54YLDNNVfw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
       "cpu": [
         "arm64"
       ],
@@ -485,9 +485,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.10.tgz",
-      "integrity": "sha512-EOGVLK1oWMBXgfttJdPHDTiivYSjX6jDNaATeNOaCOFEVcfMjtbx7WVQwPSE1eIfCp/CaSF2nSrDtzc4I9f8TQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
       "cpu": [
         "ia32"
       ],
@@ -501,9 +501,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.10.tgz",
-      "integrity": "sha512-whqLG6Sc70AbU73fFYvuYzaE4MNMBIlR1Y/IrUeOXFrWHxBEjjbZaQ3IXIQS8wJdAzue2GwYZCjOrgrU1oUHoA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
       "cpu": [
         "x64"
       ],
@@ -576,9 +576,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.1.tgz",
-      "integrity": "sha512-6vMdBZqtq1dVQ4CWdhFwhKZL6E4L1dV6jUjuBvsavvNJSppzi6dLBbuV+3+IyUREaj9ZFvQefnQm28v4OCXlig==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.3.tgz",
+      "integrity": "sha512-X9alQ3XM6I9IlSlmC8ddAvMSyG1WuHk5oUnXGw+yUBs3BFoTizmG1La/Gr8fVJvDWAq+zlYTZ9DBgrlKRVY06g==",
       "cpu": [
         "arm"
       ],
@@ -589,9 +589,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.1.tgz",
-      "integrity": "sha512-Jto9Fl3YQ9OLsTDWtLFPtaIMSL2kwGyGoVCmPC8Gxvym9TCZm4Sie+cVeblPO66YZsYH8MhBKDMGZ2NDxuk/XQ==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.3.tgz",
+      "integrity": "sha512-eQK5JIi+POhFpzk+LnjKIy4Ks+pwJ+NXmPxOCSvOKSNRPONzKuUvWE+P9JxGZVxrtzm6BAYMaL50FFuPe0oWMQ==",
       "cpu": [
         "arm64"
       ],
@@ -602,9 +602,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.1.tgz",
-      "integrity": "sha512-LtYcLNM+bhsaKAIGwVkh5IOWhaZhjTfNOkGzGqdHvhiCUVuJDalvDxEdSnhFzAn+g23wgsycmZk1vbnaibZwwA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.3.tgz",
+      "integrity": "sha512-Od4vE6f6CTT53yM1jgcLqNfItTsLt5zE46fdPaEmeFHvPs5SjZYlLpHrSiHEKR1+HdRfxuzXHjDOIxQyC3ptBA==",
       "cpu": [
         "arm64"
       ],
@@ -615,9 +615,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.1.tgz",
-      "integrity": "sha512-KyP/byeXu9V+etKO6Lw3E4tW4QdcnzDG/ake031mg42lob5tN+5qfr+lkcT/SGZaH2PdW4Z1NX9GHEkZ8xV7og==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.3.tgz",
+      "integrity": "sha512-0IMAO21axJeNIrvS9lSe/PGthc8ZUS+zC53O0VhF5gMxfmcKAP4ESkKOCwEi6u2asUrt4mQv2rjY8QseIEb1aw==",
       "cpu": [
         "x64"
       ],
@@ -628,9 +628,22 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.1.tgz",
-      "integrity": "sha512-Yqz/Doumf3QTKplwGNrCHe/B2p9xqDghBZSlAY0/hU6ikuDVQuOUIpDP/YcmoT+447tsZTmirmjgG3znvSCR0Q==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.3.tgz",
+      "integrity": "sha512-ge2DC7tHRHa3caVEoSbPRJpq7azhG+xYsd6u2MEnJ6XzPSzQsTKyXvh6iWjXRf7Rt9ykIUWHtl0Uz3T6yXPpKw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.14.3.tgz",
+      "integrity": "sha512-ljcuiDI4V3ySuc7eSk4lQ9wU8J8r8KrOUvB2U+TtK0TiW6OFDmJ+DdIjjwZHIw9CNxzbmXY39wwpzYuFDwNXuw==",
       "cpu": [
         "arm"
       ],
@@ -641,9 +654,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.1.tgz",
-      "integrity": "sha512-u3XkZVvxcvlAOlQJ3UsD1rFvLWqu4Ef/Ggl40WAVCuogf4S1nJPHh5RTgqYFpCOvuGJ7H5yGHabjFKEZGExk5Q==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.3.tgz",
+      "integrity": "sha512-Eci2us9VTHm1eSyn5/eEpaC7eP/mp5n46gTRB3Aar3BgSvDQGJZuicyq6TsH4HngNBgVqC5sDYxOzTExSU+NjA==",
       "cpu": [
         "arm64"
       ],
@@ -654,9 +667,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.1.tgz",
-      "integrity": "sha512-0XSYN/rfWShW+i+qjZ0phc6vZ7UWI8XWNz4E/l+6edFt+FxoEghrJHjX1EY/kcUGCnZzYYRCl31SNdfOi450Aw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.3.tgz",
+      "integrity": "sha512-UrBoMLCq4E92/LCqlh+blpqMz5h1tJttPIniwUgOFJyjWI1qrtrDhhpHPuFxULlUmjFHfloWdixtDhSxJt5iKw==",
       "cpu": [
         "arm64"
       ],
@@ -666,10 +679,23 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.3.tgz",
+      "integrity": "sha512-5aRjvsS8q1nWN8AoRfrq5+9IflC3P1leMoy4r2WjXyFqf3qcqsxRCfxtZIV58tCxd+Yv7WELPcO9mY9aeQyAmw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.1.tgz",
-      "integrity": "sha512-LmYIO65oZVfFt9t6cpYkbC4d5lKHLYv5B4CSHRpnANq0VZUQXGcCPXHzbCXCz4RQnx7jvlYB1ISVNCE/omz5cw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.3.tgz",
+      "integrity": "sha512-sk/Qh1j2/RJSX7FhEpJn8n0ndxy/uf0kI/9Zc4b1ELhqULVdTfN6HL31CDaTChiBAOgLcsJ1sgVZjWv8XNEsAQ==",
       "cpu": [
         "riscv64"
       ],
@@ -679,10 +705,23 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.3.tgz",
+      "integrity": "sha512-jOO/PEaDitOmY9TgkxF/TQIjXySQe5KVYB57H/8LRP/ux0ZoO8cSHCX17asMSv3ruwslXW/TLBcxyaUzGRHcqg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.1.tgz",
-      "integrity": "sha512-kr8rEPQ6ns/Lmr/hiw8sEVj9aa07gh1/tQF2Y5HrNCCEPiCBGnBUt9tVusrcBBiJfIt1yNaXN6r1CCmpbFEDpg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.3.tgz",
+      "integrity": "sha512-8ybV4Xjy59xLMyWo3GCfEGqtKV5M5gCSrZlxkPGvEPCGDLNla7v48S662HSGwRd6/2cSneMQWiv+QzcttLrrOA==",
       "cpu": [
         "x64"
       ],
@@ -693,9 +732,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.1.tgz",
-      "integrity": "sha512-t4QSR7gN+OEZLG0MiCgPqMWZGwmeHhsM4AkegJ0Kiy6TnJ9vZ8dEIwHw1LcZKhbHxTY32hp9eVCMdR3/I8MGRw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.3.tgz",
+      "integrity": "sha512-s+xf1I46trOY10OqAtZ5Rm6lzHre/UiLA1J2uOhCFXWkbZrJRkYBPO6FhvGfHmdtQ3Bx793MNa7LvoWFAm93bg==",
       "cpu": [
         "x64"
       ],
@@ -706,9 +745,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.1.tgz",
-      "integrity": "sha512-7XI4ZCBN34cb+BH557FJPmh0kmNz2c25SCQeT9OiFWEgf8+dL6ZwJ8f9RnUIit+j01u07Yvrsuu1rZGxJCc51g==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.3.tgz",
+      "integrity": "sha512-+4h2WrGOYsOumDQ5S2sYNyhVfrue+9tc9XcLWLh+Kw3UOxAvrfOrSMFon60KspcDdytkNDh7K2Vs6eMaYImAZg==",
       "cpu": [
         "arm64"
       ],
@@ -719,9 +758,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.1.tgz",
-      "integrity": "sha512-yE5c2j1lSWOH5jp+Q0qNL3Mdhr8WuqCNVjc6BxbVfS5cAS6zRmdiw7ktb8GNpDCEUJphILY6KACoFoRtKoqNQg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.3.tgz",
+      "integrity": "sha512-T1l7y/bCeL/kUwh9OD4PQT4aM7Bq43vX05htPJJ46RTI4r5KNt6qJRzAfNfM+OYMNEVBWQzR2Gyk+FXLZfogGw==",
       "cpu": [
         "ia32"
       ],
@@ -732,9 +771,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.1.tgz",
-      "integrity": "sha512-PyJsSsafjmIhVgaI1Zdj7m8BB8mMckFah/xbpplObyHfiXzKcI5UOUXRyOdHW7nz4DpMCuzLnF7v5IWHenCwYA==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.3.tgz",
+      "integrity": "sha512-/BypzV0H1y1HzgYpxqRaXGBRqfodgoBBCcsrujT6QRcakDQdfU+Lq9PENPh5jB4I44YWq+0C2eHsHya+nZY1sA==",
       "cpu": [
         "x64"
       ],
@@ -748,6 +787,12 @@
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
     "node_modules/@vitest/expect": {
@@ -1944,9 +1989,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "dev": true,
       "funding": [
         {
@@ -1965,7 +2010,7 @@
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -2019,10 +2064,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.1.tgz",
-      "integrity": "sha512-pgPO9DWzLoW/vIhlSoDByCzcpX92bKEorbgXuZrqxByte3JFk2xSW2JEeAcyLc9Ru9pqcNNW+Ob7ntsk2oT/Xw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.3.tgz",
+      "integrity": "sha512-ag5tTQKYsj1bhrFC9+OEWqb5O6VYgtQDO9hPDBMmIbePwhfSr+ExlcU741t8Dhw5DkPCQf6noz0jb36D6W9/hw==",
       "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -2031,19 +2079,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.9.1",
-        "@rollup/rollup-android-arm64": "4.9.1",
-        "@rollup/rollup-darwin-arm64": "4.9.1",
-        "@rollup/rollup-darwin-x64": "4.9.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.9.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.9.1",
-        "@rollup/rollup-linux-arm64-musl": "4.9.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.9.1",
-        "@rollup/rollup-linux-x64-gnu": "4.9.1",
-        "@rollup/rollup-linux-x64-musl": "4.9.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.9.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.9.1",
-        "@rollup/rollup-win32-x64-msvc": "4.9.1",
+        "@rollup/rollup-android-arm-eabi": "4.14.3",
+        "@rollup/rollup-android-arm64": "4.14.3",
+        "@rollup/rollup-darwin-arm64": "4.14.3",
+        "@rollup/rollup-darwin-x64": "4.14.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.14.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.14.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.14.3",
+        "@rollup/rollup-linux-arm64-musl": "4.14.3",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.14.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.14.3",
+        "@rollup/rollup-linux-x64-gnu": "4.14.3",
+        "@rollup/rollup-linux-x64-musl": "4.14.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.14.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.14.3",
+        "@rollup/rollup-win32-x64-msvc": "4.14.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -2138,9 +2189,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2289,9 +2340,9 @@
       "integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA=="
     },
     "node_modules/undici": {
-      "version": "5.28.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
-      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
@@ -2301,14 +2352,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.10.tgz",
-      "integrity": "sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==",
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.9.tgz",
+      "integrity": "sha512-uOQWfuZBlc6Y3W/DTuQ1Sr+oIXWvqljLvS881SVmAj00d5RdgShLcuXWxseWPd4HXwiYBFW/vXHfKFeqj9uQnw==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.19.3",
-        "postcss": "^8.4.32",
-        "rollup": "^4.2.0"
+        "esbuild": "^0.20.1",
+        "postcss": "^8.4.38",
+        "rollup": "^4.13.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2378,9 +2429,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.10.tgz",
-      "integrity": "sha512-YSRRs2zOpwypck+6GL3wGXx2gNP7DXzetmo5pHXLrY/VIMsS59yKfjPizQ4lLt5vEI80M41gjm2BxrGZ5U+VMA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
       "cpu": [
         "arm64"
       ],
@@ -2394,9 +2445,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.10.tgz",
-      "integrity": "sha512-S1Y27QGt/snkNYrRcswgRFqZjaTG5a5xM3EQo97uNBnH505pdzSNe/HLBq1v0RO7iK/ngdbhJB6mDAp0OK+iUA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -2406,29 +2457,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.19.10",
-        "@esbuild/android-arm": "0.19.10",
-        "@esbuild/android-arm64": "0.19.10",
-        "@esbuild/android-x64": "0.19.10",
-        "@esbuild/darwin-arm64": "0.19.10",
-        "@esbuild/darwin-x64": "0.19.10",
-        "@esbuild/freebsd-arm64": "0.19.10",
-        "@esbuild/freebsd-x64": "0.19.10",
-        "@esbuild/linux-arm": "0.19.10",
-        "@esbuild/linux-arm64": "0.19.10",
-        "@esbuild/linux-ia32": "0.19.10",
-        "@esbuild/linux-loong64": "0.19.10",
-        "@esbuild/linux-mips64el": "0.19.10",
-        "@esbuild/linux-ppc64": "0.19.10",
-        "@esbuild/linux-riscv64": "0.19.10",
-        "@esbuild/linux-s390x": "0.19.10",
-        "@esbuild/linux-x64": "0.19.10",
-        "@esbuild/netbsd-x64": "0.19.10",
-        "@esbuild/openbsd-x64": "0.19.10",
-        "@esbuild/sunos-x64": "0.19.10",
-        "@esbuild/win32-arm64": "0.19.10",
-        "@esbuild/win32-ia32": "0.19.10",
-        "@esbuild/win32-x64": "0.19.10"
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
       }
     },
     "node_modules/vitest": {

--- a/image/src/routes/ipfs.ts
+++ b/image/src/routes/ipfs.ts
@@ -1,6 +1,5 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
-import { cache } from 'hono/cache'
 import { CACHE_DAY, Env } from '../utils/constants'
 import { fetchIPFS } from '../utils/ipfs'
 import { getImageByPath, ipfsToCFI } from '../utils/cloudflare-images'
@@ -10,133 +9,126 @@ import type { ResponseType } from '../utils/types'
 const app = new Hono<{ Bindings: Env }>()
 
 app.use('/*', cors({ origin: allowedOrigin }))
-app.get(
-  '/*',
-  cache({
-    cacheName: 'ipfs-path',
-    cacheControl: 'max-age=86400, stale-while-revalidate=3600',
-  }),
-  async (c) => {
-    const { original } = c.req.query()
-    const isOriginal = original === 'true'
-    const isHead = c.req.method === 'HEAD'
+app.get('/*', async (c) => {
+  const { original } = c.req.query()
+  const isOriginal = original === 'true'
+  const isHead = c.req.method === 'HEAD'
 
-    const url = new URL(c.req.url)
-    const path = url.pathname.replace('/ipfs/', '')
-    const fullPath = `${path}${url.search}`
+  const url = new URL(c.req.url)
+  const path = url.pathname.replace('/ipfs/', '')
+  const fullPath = `${path}${url.search}`
 
-    // contruct r2 object
-    const objectName = `ipfs/${path}`
-    const object = await c.env.MY_BUCKET.get(objectName)
-    // TODO: check which one is faster to get mimeType from r2 or kv (probably kv, because only store mimeType string on kv)
-    const mimeType = object?.httpMetadata?.contentType
-    console.log('object', object)
-    console.log('mime type', mimeType)
+  // contruct r2 object
+  const objectName = `ipfs/${path}`
+  const object = await c.env.MY_BUCKET.get(objectName)
+  // TODO: check which one is faster to get mimeType from r2 or kv (probably kv, because only store mimeType string on kv)
+  const mimeType = object?.httpMetadata?.contentType
+  console.log('object', object)
+  console.log('mime type', mimeType)
 
-    // 1. check existing image on cf-images && !isOriginal
-    // ----------------------------------------
-    console.log('step 1')
-    if (mimeType?.includes('image') && !isOriginal && !isHead) {
-      const publicUrl = await getImageByPath({
-        token: c.env.IMAGE_API_TOKEN,
-        imageAccount: c.env.CF_IMAGE_ACCOUNT,
-        path: fullPath,
-      })
+  // 1. check existing image on cf-images && !isOriginal
+  // ----------------------------------------
+  console.log('step 1')
+  if (mimeType?.includes('image') && !isOriginal && !isHead) {
+    const publicUrl = await getImageByPath({
+      token: c.env.IMAGE_API_TOKEN,
+      imageAccount: c.env.CF_IMAGE_ACCOUNT,
+      path: fullPath,
+    })
 
-      if (publicUrl) {
-        return c.redirect(publicUrl)
-      }
-    }
-
-    // 2. upload images to cf-images and return it if !isOriginal
-    // ----------------------------------------
-    console.log('step 2')
-    if (!isOriginal && !isHead) {
-      const imageUrl = await ipfsToCFI({
-        path,
-        token: c.env.IMAGE_API_TOKEN,
-        gateway: c.env.DEDICATED_BACKUP_GATEWAY,
-        imageAccount: c.env.CF_IMAGE_ACCOUNT,
-      })
-
-      if (imageUrl) {
-        return c.redirect(imageUrl)
-      }
-    }
-
-    // 3. check existing object on r2
-    // ----------------------------------------
-    console.log('step 3')
-    const renderR2Object = (r2Object: R2ObjectBody, mime?: string) => {
-      // add trailing slash for html
-      if (mime?.includes('html')) {
-        // add trailing slash
-        if (!url.pathname.endsWith('/')) {
-          return c.redirect(`${url.pathname}/${url.search}`)
-        }
-      }
-
-      const headers = new Headers()
-      r2Object.writeHttpMetadata(headers)
-      headers.set('etag', r2Object.httpEtag)
-
-      const statusCode = c.req.raw.headers.get('range') !== null ? 206 : 200
-
-      const response = new Response(r2Object.body, {
-        headers,
-        status: r2Object.body ? statusCode : 304,
-      })
-
-      response.headers.append('cache-control', `s-maxage=${CACHE_DAY}`)
-      response.headers.append(
-        'content-range',
-        `bytes 0-${r2Object.size - 1}/${r2Object.size}`
-      )
-
-      return response
-    }
-
-    if (object !== null) {
-      return renderR2Object(object, mimeType)
-    }
-
-    // 4. upload object to r2
-    // ----------------------------------------
-    console.log('step 4')
-    if (object === null) {
-      const status = await fetchIPFS({
-        path: fullPath,
-        gateway1: c.env.DEDICATED_GATEWAY,
-        gateway2: c.env.DEDICATED_BACKUP_GATEWAY,
-      })
-
-      const contentLength = status.response?.headers.get('content-length')
-
-      if (status.ok && status.response?.body && status.response?.headers) {
-        let body
-
-        if (contentLength === null) {
-          body = await status.response?.text()
-        } else {
-          body = status.response.body as ResponseType
-        }
-
-        await c.env.MY_BUCKET.put(objectName, body, {
-          httpMetadata: status.response.headers,
-        })
-      }
-    }
-
-    // 5. return object from r2
-    // ----------------------------------------
-    console.log('step 5')
-    const newObject = await c.env.MY_BUCKET.get(objectName)
-
-    if (newObject !== null) {
-      return renderR2Object(newObject, newObject?.httpMetadata?.contentType)
+    if (publicUrl) {
+      return c.redirect(publicUrl)
     }
   }
-)
+
+  // 2. upload images to cf-images and return it if !isOriginal
+  // ----------------------------------------
+  console.log('step 2')
+  if (!isOriginal && !isHead) {
+    const imageUrl = await ipfsToCFI({
+      path,
+      token: c.env.IMAGE_API_TOKEN,
+      gateway: c.env.DEDICATED_BACKUP_GATEWAY,
+      imageAccount: c.env.CF_IMAGE_ACCOUNT,
+    })
+
+    if (imageUrl) {
+      return c.redirect(imageUrl)
+    }
+  }
+
+  // 3. check existing object on r2
+  // ----------------------------------------
+  console.log('step 3')
+  const renderR2Object = (r2Object: R2ObjectBody, mime?: string) => {
+    // add trailing slash for html
+    if (mime?.includes('html')) {
+      // add trailing slash
+      if (!url.pathname.endsWith('/')) {
+        return c.redirect(`${url.pathname}/${url.search}`)
+      }
+    }
+
+    const headers = new Headers()
+    r2Object.writeHttpMetadata(headers)
+    headers.set('etag', r2Object.httpEtag)
+
+    const statusCode = c.req.raw.headers.get('range') !== null ? 206 : 200
+
+    const response = new Response(r2Object.body, {
+      headers,
+      status: r2Object.body ? statusCode : 304,
+    })
+
+    response.headers.append('cache-control', `s-maxage=${CACHE_DAY}`)
+    response.headers.append(
+      'content-range',
+      `bytes 0-${r2Object.size - 1}/${r2Object.size}`
+    )
+
+    return response
+  }
+
+  if (object !== null) {
+    return renderR2Object(object, mimeType)
+  }
+
+  // 4. upload object to r2
+  // ----------------------------------------
+  console.log('step 4')
+  if (object === null) {
+    const status = await fetchIPFS({
+      path: fullPath,
+      gateway1: c.env.DEDICATED_GATEWAY,
+      gateway2: c.env.DEDICATED_BACKUP_GATEWAY,
+    })
+
+    const contentLength = status.response?.headers.get('content-length')
+
+    if (status.ok && status.response?.body && status.response?.headers) {
+      let body
+
+      if (contentLength === null) {
+        body = await status.response?.text()
+      } else {
+        body = status.response.body as ResponseType
+      }
+
+      await c.env.MY_BUCKET.put(objectName, body, {
+        httpMetadata: status.response.headers,
+      })
+    }
+  }
+
+  // 5. return object from r2
+  // ----------------------------------------
+  console.log('step 5')
+  const newObject = await c.env.MY_BUCKET.get(objectName)
+
+  if (newObject !== null) {
+    return renderR2Object(newObject, newObject?.httpMetadata?.contentType)
+  }
+})
 
 app.delete('/*', async (c) => {
   const url = new URL(c.req.url)

--- a/image/src/routes/ipfs.ts
+++ b/image/src/routes/ipfs.ts
@@ -41,25 +41,9 @@ app.get('/*', async (c) => {
     }
   }
 
-  // 2. upload images to cf-images and return it if !isOriginal
+  // 2. check existing object on r2
   // ----------------------------------------
   console.log('step 2')
-  if (mimeType?.includes('image') && !isOriginal && !isHead) {
-    const imageUrl = await ipfsToCFI({
-      path,
-      token: c.env.IMAGE_API_TOKEN,
-      gateway: c.env.DEDICATED_BACKUP_GATEWAY,
-      imageAccount: c.env.CF_IMAGE_ACCOUNT,
-    })
-
-    if (imageUrl) {
-      return c.redirect(imageUrl)
-    }
-  }
-
-  // 3. check object from r2
-  // ----------------------------------------
-  console.log('step 3')
   const renderR2Object = (r2Object: R2ObjectBody, mime?: string) => {
     // add trailing slash for html
     if (mime?.includes('html')) {
@@ -93,9 +77,9 @@ app.get('/*', async (c) => {
     return renderR2Object(object, mimeType)
   }
 
-  // 4. upload object to r2
+  // 3. upload object to r2
   // ----------------------------------------
-  console.log('step 4')
+  console.log('step 3')
   if (object === null) {
     const status = await fetchIPFS({
       path: fullPath,
@@ -117,6 +101,22 @@ app.get('/*', async (c) => {
       await c.env.MY_BUCKET.put(objectName, body, {
         httpMetadata: status.response.headers,
       })
+    }
+  }
+
+  // 4. upload images to cf-images and return it if !isOriginal
+  // ----------------------------------------
+  console.log('step 4')
+  if (!isOriginal && !isHead) {
+    const imageUrl = await ipfsToCFI({
+      path,
+      token: c.env.IMAGE_API_TOKEN,
+      gateway: c.env.DEDICATED_BACKUP_GATEWAY,
+      imageAccount: c.env.CF_IMAGE_ACCOUNT,
+    })
+
+    if (imageUrl) {
+      return c.redirect(imageUrl)
     }
   }
 

--- a/image/src/routes/ipfs.ts
+++ b/image/src/routes/ipfs.ts
@@ -1,6 +1,5 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
-import { cache } from 'hono/cache'
 import { CACHE_DAY, Env } from '../utils/constants'
 import { fetchIPFS } from '../utils/ipfs'
 import { getImageByPath, ipfsToCFI } from '../utils/cloudflare-images'
@@ -10,131 +9,124 @@ import type { ResponseType } from '../utils/types'
 const app = new Hono<{ Bindings: Env }>()
 
 app.use('/*', cors({ origin: allowedOrigin }))
-app.get(
-  '/*',
-  cache({
-    cacheName: 'ipfs-path',
-    cacheControl: 'max-age=86400, stale-while-revalidate=3600',
-  }),
-  async (c) => {
-    const { original } = c.req.query()
-    const isOriginal = original === 'true'
-    const isHead = c.req.method === 'HEAD'
+app.get('/*', async (c) => {
+  const { original } = c.req.query()
+  const isOriginal = original === 'true'
+  const isHead = c.req.method === 'HEAD'
 
-    const url = new URL(c.req.url)
-    const path = url.pathname.replace('/ipfs/', '')
-    const fullPath = `${path}${url.search}`
+  const url = new URL(c.req.url)
+  const path = url.pathname.replace('/ipfs/', '')
+  const fullPath = `${path}${url.search}`
 
-    // contruct r2 object
-    const objectName = `ipfs/${path}`
-    const object = await c.env.MY_BUCKET.get(objectName)
-    // TODO: check which one is faster to get mimeType from r2 or kv (probably kv, because only store mimeType string on kv)
-    const mimeType = object?.httpMetadata?.contentType
-    console.log('object', object)
-    console.log('mime type', mimeType)
+  // contruct r2 object
+  const objectName = `ipfs/${path}`
+  const object = await c.env.MY_BUCKET.get(objectName)
+  // TODO: check which one is faster to get mimeType from r2 or kv (probably kv, because only store mimeType string on kv)
+  const mimeType = object?.httpMetadata?.contentType
+  console.log('object', object)
+  console.log('mime type', mimeType)
 
-    // 1. check existing image on cf-images && !isOriginal
-    // ----------------------------------------
-    console.log('step 1')
-    if (mimeType?.includes('image') && !isOriginal && !isHead) {
-      const publicUrl = await getImageByPath({
-        token: c.env.IMAGE_API_TOKEN,
-        imageAccount: c.env.CF_IMAGE_ACCOUNT,
-        path: fullPath,
-      })
-
-      if (publicUrl) {
-        return c.redirect(publicUrl)
-      }
-    }
-
-    // 2. check object from r2
-    // ----------------------------------------
-    console.log('step 2')
-    const renderR2Object = (r2Object: R2ObjectBody, mime?: string) => {
-      // add trailing slash for html
-      if (mime?.includes('html')) {
-        // add trailing slash
-        if (!url.pathname.endsWith('/')) {
-          return c.redirect(`${url.pathname}/${url.search}`)
-        }
-      }
-
-      const headers = new Headers()
-      r2Object.writeHttpMetadata(headers)
-      headers.set('etag', r2Object.httpEtag)
-
-      const statusCode = c.req.raw.headers.get('range') !== null ? 206 : 200
-
-      const response = new Response(r2Object.body, {
-        headers,
-        status: r2Object.body ? statusCode : 304,
-      })
-
-      response.headers.append('cache-control', `s-maxage=${CACHE_DAY}`)
-      response.headers.append(
-        'content-range',
-        `bytes 0-${r2Object.size - 1}/${r2Object.size}`
-      )
-
-      return response
-    }
-
-    if (object !== null) {
-      return renderR2Object(object, mimeType)
-    }
-
-    // 3. upload object to r2
-    // ----------------------------------------
-    console.log('step 3')
-    if (object === null) {
-      const status = await fetchIPFS({
-        path: fullPath,
-        gateway1: c.env.DEDICATED_GATEWAY,
-        gateway2: c.env.DEDICATED_BACKUP_GATEWAY,
-      })
-
-      const contentLength = status.response?.headers.get('content-length')
-
-      if (status.ok && status.response?.body && status.response?.headers) {
-        let body
-
-        if (contentLength === null) {
-          body = await status.response?.text()
-        } else {
-          body = status.response.body as ResponseType
-        }
-
-        await c.env.MY_BUCKET.put(objectName, body, {
-          httpMetadata: status.response.headers,
-        })
-      }
-    }
-
-    // 4. upload images to cf-images and return it if !isOriginal
-    // ----------------------------------------
-    console.log('step 4')
-    const imageUrl = await ipfsToCFI({
-      path,
+  // 1. check existing image on cf-images && !isOriginal
+  // ----------------------------------------
+  console.log('step 1')
+  if (mimeType?.includes('image') && !isOriginal && !isHead) {
+    const publicUrl = await getImageByPath({
       token: c.env.IMAGE_API_TOKEN,
-      gateway: c.env.DEDICATED_GATEWAY,
       imageAccount: c.env.CF_IMAGE_ACCOUNT,
+      path: fullPath,
     })
 
-    if (imageUrl && !isOriginal && !isHead) {
-      return c.redirect(imageUrl)
-    }
-
-    // 5. return object from r2
-    // ----------------------------------------
-    console.log('step 5')
-    const newObject = await c.env.MY_BUCKET.get(objectName)
-
-    if (newObject !== null) {
-      return renderR2Object(newObject, newObject?.httpMetadata?.contentType)
+    if (publicUrl) {
+      return c.redirect(publicUrl)
     }
   }
-)
+
+  // 2. check object from r2
+  // ----------------------------------------
+  console.log('step 2')
+  const renderR2Object = (r2Object: R2ObjectBody, mime?: string) => {
+    // add trailing slash for html
+    if (mime?.includes('html')) {
+      // add trailing slash
+      if (!url.pathname.endsWith('/')) {
+        return c.redirect(`${url.pathname}/${url.search}`)
+      }
+    }
+
+    const headers = new Headers()
+    r2Object.writeHttpMetadata(headers)
+    headers.set('etag', r2Object.httpEtag)
+
+    const statusCode = c.req.raw.headers.get('range') !== null ? 206 : 200
+
+    const response = new Response(r2Object.body, {
+      headers,
+      status: r2Object.body ? statusCode : 304,
+    })
+
+    response.headers.append('cache-control', `s-maxage=${CACHE_DAY}`)
+    response.headers.append(
+      'content-range',
+      `bytes 0-${r2Object.size - 1}/${r2Object.size}`
+    )
+
+    return response
+  }
+
+  if (object !== null) {
+    return renderR2Object(object, mimeType)
+  }
+
+  // 3. upload object to r2
+  // ----------------------------------------
+  console.log('step 3')
+  if (object === null) {
+    const status = await fetchIPFS({
+      path: fullPath,
+      gateway1: c.env.DEDICATED_GATEWAY,
+      gateway2: c.env.DEDICATED_BACKUP_GATEWAY,
+    })
+
+    const contentLength = status.response?.headers.get('content-length')
+
+    if (status.ok && status.response?.body && status.response?.headers) {
+      let body
+
+      if (contentLength === null) {
+        body = await status.response?.text()
+      } else {
+        body = status.response.body as ResponseType
+      }
+
+      await c.env.MY_BUCKET.put(objectName, body, {
+        httpMetadata: status.response.headers,
+      })
+    }
+  }
+
+  // 4. upload images to cf-images and return it if !isOriginal
+  // ----------------------------------------
+  console.log('step 4')
+  const imageUrl = await ipfsToCFI({
+    path,
+    token: c.env.IMAGE_API_TOKEN,
+    gateway: c.env.DEDICATED_GATEWAY,
+    imageAccount: c.env.CF_IMAGE_ACCOUNT,
+  })
+
+  if (imageUrl && !isOriginal && !isHead) {
+    return c.redirect(imageUrl)
+  }
+
+  // 5. return object from r2
+  // ----------------------------------------
+  console.log('step 5')
+  const newObject = await c.env.MY_BUCKET.get(objectName)
+
+  if (newObject !== null) {
+    return renderR2Object(newObject, newObject?.httpMetadata?.contentType)
+  }
+})
 
 app.delete('/*', async (c) => {
   const url = new URL(c.req.url)

--- a/image/src/routes/ipfs.ts
+++ b/image/src/routes/ipfs.ts
@@ -48,7 +48,7 @@ app.get('/*', async (c) => {
     const imageUrl = await ipfsToCFI({
       path,
       token: c.env.IMAGE_API_TOKEN,
-      gateway: c.env.DEDICATED_GATEWAY,
+      gateway: c.env.DEDICATED_BACKUP_GATEWAY,
       imageAccount: c.env.CF_IMAGE_ACCOUNT,
     })
 

--- a/image/src/routes/ipfs.ts
+++ b/image/src/routes/ipfs.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
+import { cache } from 'hono/cache'
 import { CACHE_DAY, Env } from '../utils/constants'
 import { fetchIPFS } from '../utils/ipfs'
 import { getImageByPath, ipfsToCFI } from '../utils/cloudflare-images'
@@ -9,126 +10,133 @@ import type { ResponseType } from '../utils/types'
 const app = new Hono<{ Bindings: Env }>()
 
 app.use('/*', cors({ origin: allowedOrigin }))
-app.get('/*', async (c) => {
-  const { original } = c.req.query()
-  const isOriginal = original === 'true'
-  const isHead = c.req.method === 'HEAD'
+app.get(
+  '/*',
+  cache({
+    cacheName: 'ipfs-path',
+    cacheControl: 'max-age=86400, stale-while-revalidate=3600',
+  }),
+  async (c) => {
+    const { original } = c.req.query()
+    const isOriginal = original === 'true'
+    const isHead = c.req.method === 'HEAD'
 
-  const url = new URL(c.req.url)
-  const path = url.pathname.replace('/ipfs/', '')
-  const fullPath = `${path}${url.search}`
+    const url = new URL(c.req.url)
+    const path = url.pathname.replace('/ipfs/', '')
+    const fullPath = `${path}${url.search}`
 
-  // contruct r2 object
-  const objectName = `ipfs/${path}`
-  const object = await c.env.MY_BUCKET.get(objectName)
-  // TODO: check which one is faster to get mimeType from r2 or kv (probably kv, because only store mimeType string on kv)
-  const mimeType = object?.httpMetadata?.contentType
-  console.log('object', object)
-  console.log('mime type', mimeType)
+    // contruct r2 object
+    const objectName = `ipfs/${path}`
+    const object = await c.env.MY_BUCKET.get(objectName)
+    // TODO: check which one is faster to get mimeType from r2 or kv (probably kv, because only store mimeType string on kv)
+    const mimeType = object?.httpMetadata?.contentType
+    console.log('object', object)
+    console.log('mime type', mimeType)
 
-  // 1. check existing image on cf-images && !isOriginal
-  // ----------------------------------------
-  console.log('step 1')
-  if (mimeType?.includes('image') && !isOriginal && !isHead) {
-    const publicUrl = await getImageByPath({
-      token: c.env.IMAGE_API_TOKEN,
-      imageAccount: c.env.CF_IMAGE_ACCOUNT,
-      path: fullPath,
-    })
-
-    if (publicUrl) {
-      return c.redirect(publicUrl)
-    }
-  }
-
-  // 2. check existing object on r2
-  // ----------------------------------------
-  console.log('step 2')
-  const renderR2Object = (r2Object: R2ObjectBody, mime?: string) => {
-    // add trailing slash for html
-    if (mime?.includes('html')) {
-      // add trailing slash
-      if (!url.pathname.endsWith('/')) {
-        return c.redirect(`${url.pathname}/${url.search}`)
-      }
-    }
-
-    const headers = new Headers()
-    r2Object.writeHttpMetadata(headers)
-    headers.set('etag', r2Object.httpEtag)
-
-    const statusCode = c.req.raw.headers.get('range') !== null ? 206 : 200
-
-    const response = new Response(r2Object.body, {
-      headers,
-      status: r2Object.body ? statusCode : 304,
-    })
-
-    response.headers.append('cache-control', `s-maxage=${CACHE_DAY}`)
-    response.headers.append(
-      'content-range',
-      `bytes 0-${r2Object.size - 1}/${r2Object.size}`
-    )
-
-    return response
-  }
-
-  if (object !== null) {
-    return renderR2Object(object, mimeType)
-  }
-
-  // 3. upload object to r2
-  // ----------------------------------------
-  console.log('step 3')
-  if (object === null) {
-    const status = await fetchIPFS({
-      path: fullPath,
-      gateway1: c.env.DEDICATED_GATEWAY,
-      gateway2: c.env.DEDICATED_BACKUP_GATEWAY,
-    })
-
-    const contentLength = status.response?.headers.get('content-length')
-
-    if (status.ok && status.response?.body && status.response?.headers) {
-      let body
-
-      if (contentLength === null) {
-        body = await status.response?.text()
-      } else {
-        body = status.response.body as ResponseType
-      }
-
-      await c.env.MY_BUCKET.put(objectName, body, {
-        httpMetadata: status.response.headers,
+    // 1. check existing image on cf-images && !isOriginal
+    // ----------------------------------------
+    console.log('step 1')
+    if (mimeType?.includes('image') && !isOriginal && !isHead) {
+      const publicUrl = await getImageByPath({
+        token: c.env.IMAGE_API_TOKEN,
+        imageAccount: c.env.CF_IMAGE_ACCOUNT,
+        path: fullPath,
       })
+
+      if (publicUrl) {
+        return c.redirect(publicUrl)
+      }
+    }
+
+    // 2. upload images to cf-images and return it if !isOriginal
+    // ----------------------------------------
+    console.log('step 2')
+    if (!isOriginal && !isHead) {
+      const imageUrl = await ipfsToCFI({
+        path,
+        token: c.env.IMAGE_API_TOKEN,
+        gateway: c.env.DEDICATED_BACKUP_GATEWAY,
+        imageAccount: c.env.CF_IMAGE_ACCOUNT,
+      })
+
+      if (imageUrl) {
+        return c.redirect(imageUrl)
+      }
+    }
+
+    // 3. check existing object on r2
+    // ----------------------------------------
+    console.log('step 3')
+    const renderR2Object = (r2Object: R2ObjectBody, mime?: string) => {
+      // add trailing slash for html
+      if (mime?.includes('html')) {
+        // add trailing slash
+        if (!url.pathname.endsWith('/')) {
+          return c.redirect(`${url.pathname}/${url.search}`)
+        }
+      }
+
+      const headers = new Headers()
+      r2Object.writeHttpMetadata(headers)
+      headers.set('etag', r2Object.httpEtag)
+
+      const statusCode = c.req.raw.headers.get('range') !== null ? 206 : 200
+
+      const response = new Response(r2Object.body, {
+        headers,
+        status: r2Object.body ? statusCode : 304,
+      })
+
+      response.headers.append('cache-control', `s-maxage=${CACHE_DAY}`)
+      response.headers.append(
+        'content-range',
+        `bytes 0-${r2Object.size - 1}/${r2Object.size}`
+      )
+
+      return response
+    }
+
+    if (object !== null) {
+      return renderR2Object(object, mimeType)
+    }
+
+    // 4. upload object to r2
+    // ----------------------------------------
+    console.log('step 4')
+    if (object === null) {
+      const status = await fetchIPFS({
+        path: fullPath,
+        gateway1: c.env.DEDICATED_GATEWAY,
+        gateway2: c.env.DEDICATED_BACKUP_GATEWAY,
+      })
+
+      const contentLength = status.response?.headers.get('content-length')
+
+      if (status.ok && status.response?.body && status.response?.headers) {
+        let body
+
+        if (contentLength === null) {
+          body = await status.response?.text()
+        } else {
+          body = status.response.body as ResponseType
+        }
+
+        await c.env.MY_BUCKET.put(objectName, body, {
+          httpMetadata: status.response.headers,
+        })
+      }
+    }
+
+    // 5. return object from r2
+    // ----------------------------------------
+    console.log('step 5')
+    const newObject = await c.env.MY_BUCKET.get(objectName)
+
+    if (newObject !== null) {
+      return renderR2Object(newObject, newObject?.httpMetadata?.contentType)
     }
   }
-
-  // 4. upload images to cf-images and return it if !isOriginal
-  // ----------------------------------------
-  console.log('step 4')
-  if (!isOriginal && !isHead) {
-    const imageUrl = await ipfsToCFI({
-      path,
-      token: c.env.IMAGE_API_TOKEN,
-      gateway: c.env.DEDICATED_BACKUP_GATEWAY,
-      imageAccount: c.env.CF_IMAGE_ACCOUNT,
-    })
-
-    if (imageUrl) {
-      return c.redirect(imageUrl)
-    }
-  }
-
-  // 5. return object from r2
-  // ----------------------------------------
-  console.log('step 5')
-  const newObject = await c.env.MY_BUCKET.get(objectName)
-
-  if (newObject !== null) {
-    return renderR2Object(newObject, newObject?.httpMetadata?.contentType)
-  }
-})
+)
 
 app.delete('/*', async (c) => {
   const url = new URL(c.req.url)

--- a/image/src/routes/ipfs.ts
+++ b/image/src/routes/ipfs.ts
@@ -41,9 +41,25 @@ app.get('/*', async (c) => {
     }
   }
 
-  // 2. check object from r2
+  // 2. upload images to cf-images and return it if !isOriginal
   // ----------------------------------------
   console.log('step 2')
+  if (mimeType?.includes('image') && !isOriginal && !isHead) {
+    const imageUrl = await ipfsToCFI({
+      path,
+      token: c.env.IMAGE_API_TOKEN,
+      gateway: c.env.DEDICATED_GATEWAY,
+      imageAccount: c.env.CF_IMAGE_ACCOUNT,
+    })
+
+    if (imageUrl) {
+      return c.redirect(imageUrl)
+    }
+  }
+
+  // 3. check object from r2
+  // ----------------------------------------
+  console.log('step 3')
   const renderR2Object = (r2Object: R2ObjectBody, mime?: string) => {
     // add trailing slash for html
     if (mime?.includes('html')) {
@@ -77,9 +93,9 @@ app.get('/*', async (c) => {
     return renderR2Object(object, mimeType)
   }
 
-  // 3. upload object to r2
+  // 4. upload object to r2
   // ----------------------------------------
-  console.log('step 3')
+  console.log('step 4')
   if (object === null) {
     const status = await fetchIPFS({
       path: fullPath,
@@ -102,20 +118,6 @@ app.get('/*', async (c) => {
         httpMetadata: status.response.headers,
       })
     }
-  }
-
-  // 4. upload images to cf-images and return it if !isOriginal
-  // ----------------------------------------
-  console.log('step 4')
-  const imageUrl = await ipfsToCFI({
-    path,
-    token: c.env.IMAGE_API_TOKEN,
-    gateway: c.env.DEDICATED_GATEWAY,
-    imageAccount: c.env.CF_IMAGE_ACCOUNT,
-  })
-
-  if (imageUrl && !isOriginal && !isHead) {
-    return c.redirect(imageUrl)
   }
 
   // 5. return object from r2

--- a/image/src/utils/cloudflare-images.ts
+++ b/image/src/utils/cloudflare-images.ts
@@ -111,6 +111,7 @@ export async function getImageByPath({
     }
   )
   const image = (await getImage.json()) as CFIApiResponse
+  console.log('getImageByPath', getImage.status)
 
   if (getImage.ok && image.result) {
     const variants = image.result.variants


### PR DESCRIPTION
Fix https://github.com/kodadot/nft-gallery/discussions/10019

Context:
Timeout on filebase:

```
url: https://wsrv.nl/?url=https:%2F%2Fkodadot-ultra.myfilebase.com%2Fipfs%2Fbafybeidkqisbqo3vyejrltlaqeqkxgsvxcuqsmpnw5hczrfhhqrkbcgt3u%2F0.png&w=1400
response: {"status":"error","code":404,"message":"The requested URL timed out."}
```

Changes in this PR:
- switch gateway at the moment to Infura
- remove general cache on ipfs-path
- reorder uploading an image to cf-images

Testcase: this page should load cf-images https://canary.kodadot.xyz/ahp/drops/tilescape instead of original images