### PR TITLE
fix: quick fix to filebase

### DIFF
--- a/services/image/package.json
+++ b/services/image/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "wrangler dev",
-    "start:remote": "wrangler dev --remote",
+    "dev": "wrangler dev",
+    "dev:remote": "wrangler dev --remote",
     "deploy": "wrangler publish",
     "test": "vitest"
   },

--- a/services/image/src/routes/metadata.ts
+++ b/services/image/src/routes/metadata.ts
@@ -57,7 +57,7 @@ app.get('/*', async (c) => {
     const externalUrl = toExternalGateway(url)
     const data = await fetch(externalUrl)
     console.log('fetch metadata status', externalUrl, data.status)
-    const json = await data.json<BaseMetadata>()
+    const json = (await data.json()) as BaseMetadata
     const content = contentFrom(json, true)
     // @ts-ignore
     const normalized = normalize(content, ipfsUrl)

--- a/services/image/src/utils/ipfs.ts
+++ b/services/image/src/utils/ipfs.ts
@@ -6,7 +6,7 @@ import {
 } from '@kodadot1/minipfs'
 
 export function toIPFSDedicated(path: string) {
-  const infura = new URL(getProviderList(['infura_kodadot1'])[0])
+  const infura = new URL(getProviderList(['filebase_kodadot'])[0])
   const url = new URL(path)
   url.hostname = infura.hostname
 


### PR DESCRIPTION
## Context

- [x] infura gateways got 504 error. quick fix switch it to filebase. for proper fix backlogged here: https://github.com/kodadot/workers/issues/296

<img width="559" alt="Screenshot 2024-05-27 at 17 25 49" src="https://github.com/kodadot/workers/assets/734428/74a398d9-089a-4149-b024-665ec6375800">


## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Chore