### PR TITLE
fix: redirecct to fxart metadata

### DIFF
--- a/services/image/src/routes/metadata.ts
+++ b/services/image/src/routes/metadata.ts
@@ -43,17 +43,17 @@ app.get('/*', async (c) => {
   }
 
   try {
+    // 0 redirect to internal url
+    if (url.includes('fxart-beta.kodadot.workers.dev')) {
+      return c.redirect(url, 301)
+    }
+
     // 1. check on KV. if exists, return the data
     // ----------------------------------------
     console.log('fetch metadata', url, key)
     const metadataKV = await c.env.METADATA.get(key)
     if (metadataKV) {
       return c.json(JSON.parse(metadataKV))
-    }
-
-    // 1.1 redirect to internal url
-    if (url.includes('fxart-beta.kodadot.workers.dev')) {
-      return c.redirect(url, 301)
     }
 
     // 2. put to KV

--- a/services/image/src/routes/metadata.ts
+++ b/services/image/src/routes/metadata.ts
@@ -45,12 +45,16 @@ app.get('/*', async (c) => {
   try {
     // 1. check on KV. if exists, return the data
     // ----------------------------------------
+    console.log('fetch metadata', url, key)
     const metadataKV = await c.env.METADATA.get(key)
     if (metadataKV) {
       return c.json(JSON.parse(metadataKV))
     }
 
-    // TODO: additional layer, check metadata on R2 bucket
+    // 1.1 redirect to internal url
+    if (url.includes('fxart-beta.kodadot.workers.dev')) {
+      return c.redirect(url, 301)
+    }
 
     // 2. put to KV
     // ----------------------------------------


### PR DESCRIPTION
## Context

Quick fix this issue: https://github.com/kodadot/nft-gallery/issues/10347#issuecomment-2135257794 from image workers. There is still some glitch in the UI, but leave it fixed on the nft-gallery side: https://github.com/kodadot/nft-gallery/pull/10349

![image](https://github.com/kodadot/workers/assets/734428/ade5c7b0-8846-4d06-bace-7513d7fdc2ce)


## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Chore
