### PR TITLE
feat/image/w3s

### DIFF
--- a/services/image/src/routes/ipfs.ts
+++ b/services/image/src/routes/ipfs.ts
@@ -114,7 +114,7 @@ app.get('/*', async (c) => {
   // 4. upload object to r2
   // ----------------------------------------
   console.log('step 4', url.toString())
-  const ipfsNftstorage = toIpfsGw(url.toString(), 'nftstorage')
+  const ipfsNftstorage = toIpfsGw(url.toString(), 'w3s')
   console.log('ipfsNftstorage', ipfsNftstorage)
   const status = await fetchIPFS({
     path: fullPath,

--- a/services/image/src/utils/ipfs.ts
+++ b/services/image/src/utils/ipfs.ts
@@ -1,5 +1,5 @@
 import {
-  $purify,
+  $purifyOne,
   ipfsProviders,
   type HTTPS_URI,
   type IPFSProviders,
@@ -20,7 +20,7 @@ export function ipfsUrl(ipfs?: string) {
   }
 
   // TODO: 'kodadot_beta' for beta, 'kodadot' for prod
-  return $purify(ipfs, ['kodadot_beta'])[0]
+  return $purifyOne(ipfs, 'kodadot_beta')
 }
 
 async function resolveGateway({ path = '', gateway = ipfsProviders.ipfs }) {


### PR DESCRIPTION
- **:zap: replace nftstorage with w3s**
- **:technologist: use $purifyOne**

## Context

1. _describe why do we need this change?_

Basically indexer stops working because of -  #298


2. _what is the problem?_

The problem is that nftstorage gateway has undefined behaviour and therefore makes kodadot_beta endpoint unreliable

2. _how did you solve the problem?_

Fix is to replace nftstorage gw with w3s gw as it is a reliable source

## Ref

- [ ] Closes #<issue_number>
- [ ] References kodadot/<indexer/worker>#<issue_number>

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Chore
