### PR TITLE
🔧 ogi mnt chain

### DIFF
--- a/ogi/server/utils/evm.ts
+++ b/ogi/server/utils/evm.ts
@@ -53,7 +53,7 @@ export type ExtendedPrefix =
   | 'optimism'
   | 'avalanche'
   | 'polygon'
-  | 'mantle'
+  | 'mnt'
 
 export const chains: Record<ExtendedPrefix, Chain> = {
   base,
@@ -61,7 +61,7 @@ export const chains: Record<ExtendedPrefix, Chain> = {
   avalanche,
   polygon,
   imx,
-  mantle,
+  mnt: mantle,
 }
 
 export const thirdwebClient = createThirdwebClient({


### PR DESCRIPTION
## Context
404 not found since chain was declared `mantle` and not `mnt`

## Ref

- [ ] Closes #<issue_number>
- [x] Tested on `/api/evm/mnt/collection/0xcbae5aa4ff18053e579edfa53174236cbd71c0e6` 

## PR Type

- [x] Bugfix
- [x] Feature
