### PR TITLE
fix: ignore wsrv cache

### DIFF
--- a/services/image/src/utils/cloudflare-images.ts
+++ b/services/image/src/utils/cloudflare-images.ts
@@ -16,6 +16,7 @@ async function resizeImage(url: string) {
   const wsrvnl = new URL('https://wsrv.nl')
   wsrvnl.searchParams.append('url', url)
   wsrvnl.searchParams.append('w', '1400')
+  wsrvnl.searchParams.append('data', new Date().toISOString())
 
   console.log(wsrvnl.toString())
 
@@ -118,6 +119,25 @@ export async function getImageByPath({
   }
 
   return ''
+}
+
+export async function deleteImageByPath({ token, imageAccount, path }: CFImages & { path: string }) {
+  const deleteImage = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${imageAccount}/images/v1/${path}`,
+    {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  )
+
+  if (deleteImage.ok) {
+    return true
+  }
+
+  return false
 }
 
 const transformationParams = [


### PR DESCRIPTION
## Context

- [x] Closes https://github.com/kodadot/nft-gallery/issues/11406
- [x] seems like stuck on wsrv cache, by default the cache is 1y: https://wsrv.nl/docs/format.html#cache-control. let's try with this PR to ignore wsrv cache on revalidating cache

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Chore
